### PR TITLE
Feature/websocket flow deletion

### DIFF
--- a/assets/js/features/flow-builder/hooks/useFlowManager.ts
+++ b/assets/js/features/flow-builder/hooks/useFlowManager.ts
@@ -125,6 +125,10 @@ export function useFlowManager(flowId: string | null) {
       },
       onClientJoined: data => setConnectedClients(data.client_count),
       onClientLeft: data => setConnectedClients(data.client_count),
+      onFlowDeleted: () => {
+        // Flow has been deleted by another user, redirect to home
+        window.location.href = '/';
+      },
       onError: error => console.error('🔌❌ WebSocket connection error:', error),
     });
 

--- a/assets/js/features/home/HomePage.tsx
+++ b/assets/js/features/home/HomePage.tsx
@@ -26,7 +26,7 @@ export const HomePage: React.FC = () => {
   // Load flows on component mount
   useEffect(() => {
     loadFlows();
-    
+
     // Initialize websocket connection if not already connected
     if (!websocketService.isConnected()) {
       websocketService.connect();
@@ -100,12 +100,12 @@ export const HomePage: React.FC = () => {
     try {
       // Delete from local storage first
       flowStorage.deleteFlow(flowId);
-      
+
       // Notify websocket service about the deletion
       if (websocketService.isConnected()) {
         await websocketService.notifyFlowDeleted(flowId);
       }
-      
+
       loadFlows();
       setShowDeleteConfirm(null);
     } catch (error) {

--- a/assets/js/features/home/HomePage.tsx
+++ b/assets/js/features/home/HomePage.tsx
@@ -14,6 +14,7 @@ import {
 import { ThemeToggle } from '../flow-builder/components/ThemeToggle';
 import { flowStorage } from '../../shared/services/flowStorage';
 import { FlowRegistryEntry } from '../../shared/types/flow';
+import { websocketService } from '../../shared/services/websocketService';
 
 export const HomePage: React.FC = () => {
   const [flows, setFlows] = useState<FlowRegistryEntry[]>([]);
@@ -25,6 +26,11 @@ export const HomePage: React.FC = () => {
   // Load flows on component mount
   useEffect(() => {
     loadFlows();
+    
+    // Initialize websocket connection if not already connected
+    if (!websocketService.isConnected()) {
+      websocketService.connect();
+    }
   }, []);
 
   // Handle click outside to close dropdowns
@@ -90,10 +96,24 @@ export const HomePage: React.FC = () => {
     }
   };
 
-  const handleDeleteFlow = (flowId: string) => {
-    flowStorage.deleteFlow(flowId);
-    loadFlows();
-    setShowDeleteConfirm(null);
+  const handleDeleteFlow = async (flowId: string) => {
+    try {
+      // Delete from local storage first
+      flowStorage.deleteFlow(flowId);
+      
+      // Notify websocket service about the deletion
+      if (websocketService.isConnected()) {
+        await websocketService.notifyFlowDeleted(flowId);
+      }
+      
+      loadFlows();
+      setShowDeleteConfirm(null);
+    } catch (error) {
+      console.error('Failed to delete flow:', error);
+      // Still update UI even if websocket notification fails
+      loadFlows();
+      setShowDeleteConfirm(null);
+    }
   };
 
   const handleOpenFlow = (flowId: string) => {

--- a/assets/js/shared/services/__tests__/websocketService.test.ts
+++ b/assets/js/shared/services/__tests__/websocketService.test.ts
@@ -1,44 +1,172 @@
 import { websocketService } from '../websocketService';
 
-// Mock Phoenix
+// Mock console.error to suppress error messages during tests
+const originalConsoleError = console.error;
+beforeAll(() => {
+  console.error = jest.fn();
+});
+
+afterAll(() => {
+  console.error = originalConsoleError;
+});
+
+// Mock Phoenix with simpler implementation
+const mockChannel = {
+  join: jest.fn(),
+  leave: jest.fn(),
+  push: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+};
+
+const mockSocket = {
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  isConnected: jest.fn(() => false),
+  onOpen: jest.fn(),
+  onClose: jest.fn(),
+  onError: jest.fn(),
+  channel: jest.fn(() => mockChannel),
+};
+
 jest.mock('phoenix', () => ({
-  Socket: jest.fn(() => ({
-    connect: jest.fn(),
-    disconnect: jest.fn(),
-    isConnected: jest.fn(() => false),
-    onOpen: jest.fn(),
-    onClose: jest.fn(),
-    onError: jest.fn(),
-    channel: jest.fn(() => ({
-      join: jest.fn(),
-      leave: jest.fn(),
-      push: jest.fn(),
-      on: jest.fn(),
-      off: jest.fn(),
-    })),
-  })),
+  Socket: jest.fn(() => mockSocket),
 }));
 
 describe('websocketService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset the service to a clean state
+    websocketService.disconnect();
+
+    // Setup default mock returns
+    mockChannel.join.mockReturnValue({
+      receive: jest.fn().mockImplementation(function (status, callback) {
+        if (status === 'ok') {
+          setTimeout(() => callback({}), 0);
+        }
+        return this;
+      }),
+    });
+
+    mockChannel.push.mockReturnValue({
+      receive: jest.fn().mockImplementation(function (status, callback) {
+        if (status === 'ok') {
+          setTimeout(() => callback({ status: 'success' }), 0);
+        }
+        return this;
+      }),
+    });
   });
 
-  it('should initialize and connect', () => {
-    expect(() => websocketService.connect()).not.toThrow();
+  describe('basic connection functionality', () => {
+    it('should initialize and connect', () => {
+      expect(() => websocketService.connect()).not.toThrow();
+      expect(mockSocket.connect).toHaveBeenCalled();
+    });
+
+    it('should check connection status', () => {
+      const isConnected = websocketService.isConnected();
+      expect(typeof isConnected).toBe('boolean');
+      expect(isConnected).toBe(false);
+    });
+
+    it('should return consistent boolean values', () => {
+      const result1 = websocketService.isConnected();
+      const result2 = websocketService.isConnected();
+      expect(result1).toBe(result2);
+      expect(typeof result1).toBe('boolean');
+      expect(typeof result2).toBe('boolean');
+    });
+
+    it('should disconnect properly', () => {
+      websocketService.connect();
+      websocketService.disconnect();
+      expect(mockSocket.disconnect).toHaveBeenCalled();
+    });
   });
 
-  it('should check connection status', () => {
-    const isConnected = websocketService.isConnected();
-    expect(typeof isConnected).toBe('boolean');
-    expect(isConnected).toBe(false);
+  describe('flow management', () => {
+    beforeEach(() => {
+      websocketService.connect();
+      mockSocket.isConnected.mockReturnValue(true);
+    });
+
+    it('should attempt to join flow channel', async () => {
+      await websocketService.joinFlow('test-flow-id');
+      expect(mockSocket.channel).toHaveBeenCalledWith('flow:test-flow-id', {});
+      expect(mockChannel.join).toHaveBeenCalled();
+    });
+
+    it('should leave flow channel', () => {
+      websocketService.leaveFlow();
+      expect(mockChannel.leave).toHaveBeenCalled();
+    });
   });
 
-  it('should return consistent boolean values', () => {
-    const result1 = websocketService.isConnected();
-    const result2 = websocketService.isConnected();
-    expect(result1).toBe(result2);
-    expect(typeof result1).toBe('boolean');
-    expect(typeof result2).toBe('boolean');
+  describe('flow deletion notification', () => {
+    beforeEach(() => {
+      websocketService.connect();
+      mockSocket.isConnected.mockReturnValue(true);
+    });
+
+    it('should attempt to notify flow deletion', async () => {
+      await websocketService.notifyFlowDeleted('test-flow-id');
+
+      expect(mockSocket.channel).toHaveBeenCalledWith('flow_management', {});
+      expect(mockChannel.join).toHaveBeenCalled();
+      expect(mockChannel.push).toHaveBeenCalledWith('flow_deleted', { flow_id: 'test-flow-id' });
+      expect(mockChannel.leave).toHaveBeenCalled();
+    });
+
+    it('should handle flow deletion notification when not connected', async () => {
+      mockSocket.isConnected.mockReturnValue(false);
+      websocketService.disconnect();
+
+      const result = await websocketService.notifyFlowDeleted('test-flow-id');
+      expect(result).toBe(false);
+    });
+
+    it('should handle exceptions during flow deletion notification', async () => {
+      // Mock channel creation to throw
+      mockSocket.channel.mockImplementationOnce(() => {
+        throw new Error('Channel creation failed');
+      });
+
+      const result = await websocketService.notifyFlowDeleted('test-flow-id');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('callback management', () => {
+    it('should set callbacks', () => {
+      const callbacks = {
+        onConnect: jest.fn(),
+        onDisconnect: jest.fn(),
+        onFlowUpdate: jest.fn(),
+      };
+
+      expect(() => websocketService.setCallbacks(callbacks)).not.toThrow();
+    });
+
+    it('should get current flow ID', () => {
+      websocketService.connect();
+      mockSocket.isConnected.mockReturnValue(true);
+
+      // Initially should return null
+      expect(websocketService.getCurrentFlowId()).toBe(null);
+    });
+
+    it('should handle sendFlowChange without active channel', async () => {
+      const changes = { nodes: [], edges: [] };
+      const result = await websocketService.sendFlowChange(changes);
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle ping without active channel', async () => {
+      const result = await websocketService.ping();
+      expect(result).toBe(false);
+    });
   });
 });

--- a/assets/js/shared/services/__tests__/websocketService.test.ts
+++ b/assets/js/shared/services/__tests__/websocketService.test.ts
@@ -41,7 +41,7 @@ describe('websocketService', () => {
 
     // Setup default mock returns
     mockChannel.join.mockReturnValue({
-      receive: jest.fn().mockImplementation(function (status, callback) {
+      receive: jest.fn().mockImplementation(function (this: any, status: string, callback: (data: any) => void) {
         if (status === 'ok') {
           setTimeout(() => callback({}), 0);
         }
@@ -50,7 +50,7 @@ describe('websocketService', () => {
     });
 
     mockChannel.push.mockReturnValue({
-      receive: jest.fn().mockImplementation(function (status, callback) {
+      receive: jest.fn().mockImplementation(function (this: any, status: string, callback: (data: any) => void) {
         if (status === 'ok') {
           setTimeout(() => callback({ status: 'success' }), 0);
         }

--- a/assets/js/shared/services/__tests__/websocketService.test.ts
+++ b/assets/js/shared/services/__tests__/websocketService.test.ts
@@ -42,9 +42,9 @@ describe('websocketService', () => {
     // Setup default mock returns
     mockChannel.join.mockReturnValue({
       receive: jest.fn().mockImplementation(function (
-        this: any,
+        this: unknown,
         status: string,
-        callback: (data: any) => void
+        callback: (_data: unknown) => void
       ) {
         if (status === 'ok') {
           setTimeout(() => callback({}), 0);
@@ -55,9 +55,9 @@ describe('websocketService', () => {
 
     mockChannel.push.mockReturnValue({
       receive: jest.fn().mockImplementation(function (
-        this: any,
+        this: unknown,
         status: string,
-        callback: (data: any) => void
+        callback: (_data: unknown) => void
       ) {
         if (status === 'ok') {
           setTimeout(() => callback({ status: 'success' }), 0);

--- a/assets/js/shared/services/__tests__/websocketService.test.ts
+++ b/assets/js/shared/services/__tests__/websocketService.test.ts
@@ -41,7 +41,11 @@ describe('websocketService', () => {
 
     // Setup default mock returns
     mockChannel.join.mockReturnValue({
-      receive: jest.fn().mockImplementation(function (this: any, status: string, callback: (data: any) => void) {
+      receive: jest.fn().mockImplementation(function (
+        this: any,
+        status: string,
+        callback: (data: any) => void
+      ) {
         if (status === 'ok') {
           setTimeout(() => callback({}), 0);
         }
@@ -50,7 +54,11 @@ describe('websocketService', () => {
     });
 
     mockChannel.push.mockReturnValue({
-      receive: jest.fn().mockImplementation(function (this: any, status: string, callback: (data: any) => void) {
+      receive: jest.fn().mockImplementation(function (
+        this: any,
+        status: string,
+        callback: (data: any) => void
+      ) {
         if (status === 'ok') {
           setTimeout(() => callback({ status: 'success' }), 0);
         }

--- a/assets/js/shared/services/websocketService.ts
+++ b/assets/js/shared/services/websocketService.ts
@@ -225,8 +225,8 @@ class WebSocketService {
     try {
       // Create a temporary channel to send the deletion notification
       const tempChannel = this.socket.channel('flow_management', {});
-      
-      const result = await new Promise<boolean>((resolve) => {
+
+      const result = await new Promise<boolean>(resolve => {
         tempChannel
           .join()
           .receive('ok', () => {

--- a/assets/js/shared/services/websocketService.ts
+++ b/assets/js/shared/services/websocketService.ts
@@ -14,6 +14,7 @@ export interface WebSocketCallbacks {
   onFlowUpdate?: (_data: FlowChangeData) => void;
   onClientJoined?: (_data: ClientJoinedData) => void;
   onClientLeft?: (_data: ClientJoinedData) => void;
+  onFlowDeleted?: () => void;
   onConnect?: () => void;
   onDisconnect?: () => void;
   onError?: (_error: unknown) => void;
@@ -131,6 +132,10 @@ class WebSocketService {
 
       this.channel.on('client_left', (data: ClientJoinedData) => {
         this.callbacks.onClientLeft?.(data);
+      });
+
+      this.channel.on('flow_deleted', () => {
+        this.callbacks.onFlowDeleted?.();
       });
 
       // Join the channel

--- a/lib/helix_web/channels/flow_channel.ex
+++ b/lib/helix_web/channels/flow_channel.ex
@@ -78,6 +78,18 @@ defmodule HelixWeb.FlowChannel do
   end
 
   @impl true
+  def handle_info({:flow_deleted, flow_id}, socket) do
+    # Notify client that the flow has been deleted
+    push(socket, "flow_deleted", %{
+      flow_id: flow_id,
+      timestamp: System.system_time(:second)
+    })
+
+    # Close the channel since the flow no longer exists
+    {:stop, :normal, socket}
+  end
+
+  @impl true
   def handle_in("flow_change", %{"changes" => changes}, socket) do
     flow_id = socket.assigns.flow_id
 

--- a/lib/helix_web/channels/flow_management_channel.ex
+++ b/lib/helix_web/channels/flow_management_channel.ex
@@ -27,13 +27,13 @@ defmodule HelixWeb.FlowManagementChannel do
   @impl true
   def handle_in("flow_deleted", %{"flow_id" => flow_id}, socket) when is_binary(flow_id) do
     Logger.info("Received flow deletion notification for flow: #{flow_id}")
-    
+
     # Force close any active sessions for this flow
     case FlowSessionManager.force_close_flow_session(flow_id) do
       {:ok, closed_clients} ->
         Logger.info("Closed flow session #{flow_id} with #{closed_clients} active clients")
         {:reply, {:ok, %{status: "session_closed", clients_affected: closed_clients}}, socket}
-        
+
       {:error, reason} ->
         Logger.warning("Failed to close flow session #{flow_id}: #{inspect(reason)}")
         {:reply, {:error, %{reason: "Failed to close session"}}, socket}

--- a/lib/helix_web/channels/flow_management_channel.ex
+++ b/lib/helix_web/channels/flow_management_channel.ex
@@ -1,0 +1,61 @@
+defmodule HelixWeb.FlowManagementChannel do
+  @moduledoc """
+  Phoenix Channel for flow management operations.
+
+  Handles:
+  - Flow deletion notifications
+  - Administrative flow operations
+  """
+
+  use HelixWeb, :channel
+
+  alias Helix.FlowSessionManager
+  require Logger
+
+  @impl true
+  def join("flow_management", _payload, socket) do
+    Logger.debug("Client joined flow management channel")
+    {:ok, socket}
+  end
+
+  # Reject joins to other topics
+  @impl true
+  def join(_topic, _payload, _socket) do
+    {:error, %{reason: "Invalid management channel"}}
+  end
+
+  @impl true
+  def handle_in("flow_deleted", %{"flow_id" => flow_id}, socket) when is_binary(flow_id) do
+    Logger.info("Received flow deletion notification for flow: #{flow_id}")
+    
+    # Force close any active sessions for this flow
+    case FlowSessionManager.force_close_flow_session(flow_id) do
+      {:ok, closed_clients} ->
+        Logger.info("Closed flow session #{flow_id} with #{closed_clients} active clients")
+        {:reply, {:ok, %{status: "session_closed", clients_affected: closed_clients}}, socket}
+        
+      {:error, reason} ->
+        Logger.warning("Failed to close flow session #{flow_id}: #{inspect(reason)}")
+        {:reply, {:error, %{reason: "Failed to close session"}}, socket}
+    end
+  end
+
+  @impl true
+  def handle_in("flow_deleted", _invalid_payload, socket) do
+    Logger.warning("Invalid flow_deleted payload received")
+    {:reply, {:error, %{reason: "Invalid flow_id"}}, socket}
+  end
+
+  # Handle unknown messages
+  @impl true
+  def handle_in(event, payload, socket) do
+    Logger.warning("Unknown management event #{event} with payload: #{inspect(payload)}")
+    {:reply, {:error, %{reason: "Unknown event"}}, socket}
+  end
+
+  @impl true
+  def terminate(reason, _socket) do
+    Logger.debug("Flow management channel terminated: #{inspect(reason)}")
+    :ok
+  end
+end

--- a/lib/helix_web/channels/user_socket.ex
+++ b/lib/helix_web/channels/user_socket.ex
@@ -8,6 +8,7 @@ defmodule HelixWeb.UserSocket do
 
   ## Channels
   channel "flow:*", HelixWeb.FlowChannel
+  channel "flow_management", HelixWeb.FlowManagementChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/test/helix_web/channels/flow_management_channel_test.exs
+++ b/test/helix_web/channels/flow_management_channel_test.exs
@@ -1,0 +1,338 @@
+defmodule HelixWeb.FlowManagementChannelTest do
+  use HelixWeb.ChannelCase, async: false
+  import ExUnit.CaptureLog
+
+  alias Helix.FlowSessionManager
+  alias HelixWeb.{FlowManagementChannel, UserSocket}
+
+  setup do
+    # Start FlowSessionManager for tests
+    pid = start_supervised({FlowSessionManager, []})
+
+    on_exit(fn ->
+      case pid do
+        {:ok, pid} ->
+          Process.exit(pid, :normal)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    # Create a socket
+    {:ok, socket} = connect(UserSocket, %{}, connect_info: %{})
+
+    {:ok, socket: socket}
+  end
+
+  describe "joining flow management channel" do
+    test "successfully joins the flow_management channel", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      assert socket.topic == "flow_management"
+    end
+
+    test "rejects joins to invalid topics", %{socket: socket} do
+      assert {:error, %{reason: "Invalid management channel"}} =
+               subscribe_and_join(socket, FlowManagementChannel, "invalid_topic")
+    end
+
+    test "rejects joins to other flow management topics", %{socket: socket} do
+      assert {:error, %{reason: "Invalid management channel"}} =
+               subscribe_and_join(socket, FlowManagementChannel, "flow_management:admin")
+    end
+  end
+
+  describe "handling flow_deleted messages" do
+    test "successfully handles flow deletion with active session", %{socket: socket} do
+      flow_id = test_flow_id("delete-test-flow")
+
+      # Set up an active flow session first
+      FlowSessionManager.join_flow(flow_id, "test-client-1")
+      FlowSessionManager.join_flow(flow_id, "test-client-2")
+
+      # Verify session is active
+      assert %{active: true, client_count: 2} = FlowSessionManager.get_flow_status(flow_id)
+
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message
+      ref = push(socket, "flow_deleted", %{"flow_id" => flow_id})
+
+      # Should receive successful response
+      assert_reply ref, :ok, %{
+        status: "session_closed",
+        clients_affected: 2
+      }
+
+      # Verify session was closed
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id)
+    end
+
+    test "handles flow deletion when no active session exists", %{socket: socket} do
+      flow_id = test_flow_id("no-session-flow")
+
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message for non-existent session
+      ref = push(socket, "flow_deleted", %{"flow_id" => flow_id})
+
+      # Should still receive successful response with 0 clients affected
+      assert_reply ref, :ok, %{
+        status: "session_closed",
+        clients_affected: 0
+      }
+    end
+
+    test "handles flow deletion with single client session", %{socket: socket} do
+      flow_id = test_flow_id("single-client-flow")
+
+      # Set up a single client session
+      FlowSessionManager.join_flow(flow_id, "lone-client")
+
+      # Verify session is active
+      assert %{active: true, client_count: 1} = FlowSessionManager.get_flow_status(flow_id)
+
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message
+      ref = push(socket, "flow_deleted", %{"flow_id" => flow_id})
+
+      # Should receive successful response
+      assert_reply ref, :ok, %{
+        status: "session_closed",
+        clients_affected: 1
+      }
+
+      # Verify session was closed
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id)
+    end
+
+    test "rejects flow_deleted with invalid payload - missing flow_id", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message without flow_id
+      ref = push(socket, "flow_deleted", %{"invalid" => "payload"})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Invalid flow_id"}
+    end
+
+    test "rejects flow_deleted with invalid payload - non-string flow_id", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message with non-string flow_id
+      ref = push(socket, "flow_deleted", %{"flow_id" => 123})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Invalid flow_id"}
+    end
+
+    test "rejects flow_deleted with invalid payload - nil flow_id", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message with nil flow_id
+      ref = push(socket, "flow_deleted", %{"flow_id" => nil})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Invalid flow_id"}
+    end
+
+    test "rejects flow_deleted with empty payload", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message with empty payload
+      ref = push(socket, "flow_deleted", %{})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Invalid flow_id"}
+    end
+  end
+
+  describe "error handling during flow deletion" do
+    test "handles FlowSessionManager errors gracefully", %{socket: socket} do
+      # This test simulates a scenario where FlowSessionManager might fail
+      # We'll test with a flow_id that might cause issues
+      # Empty string might cause issues
+      flow_id = ""
+
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send flow_deleted message
+      ref = push(socket, "flow_deleted", %{"flow_id" => flow_id})
+
+      # Should handle the error and return appropriate response
+      # The exact response depends on how FlowSessionManager handles empty flow_ids
+      assert_reply ref, result, _payload
+      assert result in [:ok, :error]
+    end
+  end
+
+  describe "handling unknown messages" do
+    test "rejects unknown events with error response", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send unknown event
+      ref = push(socket, "unknown_event", %{"some" => "payload"})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Unknown event"}
+    end
+
+    test "rejects known events with wrong names", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send event with similar but wrong name
+      ref = push(socket, "flow_delete", %{"flow_id" => "test"})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Unknown event"}
+    end
+
+    test "rejects administrative events that don't exist", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Send hypothetical admin event
+      ref = push(socket, "admin_action", %{"action" => "restart"})
+
+      # Should receive error response
+      assert_reply ref, :error, %{reason: "Unknown event"}
+    end
+  end
+
+  describe "channel termination" do
+    test "handles normal termination gracefully", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Enable trap_exit to handle the expected EXIT message
+      Process.flag(:trap_exit, true)
+
+      # Close the socket
+      close(socket)
+
+      # Expect to receive the EXIT message from channel termination
+      assert_receive {:EXIT, _pid, {:shutdown, :closed}}, 1000
+
+      # Should not crash - termination should be handled gracefully
+      # The test passes if no exceptions are raised
+    end
+
+    test "handles abnormal termination gracefully" do
+      # Test that terminate/2 handles various termination reasons
+      socket = %Phoenix.Socket{
+        topic: "flow_management",
+        transport_pid: self(),
+        serializer: Jason
+      }
+
+      # Test different termination reasons
+      assert :ok = FlowManagementChannel.terminate(:normal, socket)
+      assert :ok = FlowManagementChannel.terminate({:shutdown, :closed}, socket)
+      assert :ok = FlowManagementChannel.terminate(:kill, socket)
+    end
+  end
+
+  describe "integration with FlowSessionManager" do
+    test "multiple flow deletions work independently", %{socket: socket} do
+      flow_id_1 = test_flow_id("multi-delete-1")
+      flow_id_2 = test_flow_id("multi-delete-2")
+
+      # Set up sessions for both flows
+      FlowSessionManager.join_flow(flow_id_1, "client-1")
+      FlowSessionManager.join_flow(flow_id_1, "client-2")
+      FlowSessionManager.join_flow(flow_id_2, "client-3")
+
+      # Verify both sessions are active
+      assert %{active: true, client_count: 2} = FlowSessionManager.get_flow_status(flow_id_1)
+      assert %{active: true, client_count: 1} = FlowSessionManager.get_flow_status(flow_id_2)
+
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Delete first flow
+      ref1 = push(socket, "flow_deleted", %{"flow_id" => flow_id_1})
+
+      assert_reply ref1, :ok, %{
+        status: "session_closed",
+        clients_affected: 2
+      }
+
+      # Verify first flow is closed, second is still active
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id_1)
+      assert %{active: true, client_count: 1} = FlowSessionManager.get_flow_status(flow_id_2)
+
+      # Delete second flow
+      ref2 = push(socket, "flow_deleted", %{"flow_id" => flow_id_2})
+
+      assert_reply ref2, :ok, %{
+        status: "session_closed",
+        clients_affected: 1
+      }
+
+      # Verify both flows are now closed
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id_1)
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id_2)
+    end
+
+    test "handles concurrent flow deletions", %{socket: socket} do
+      flow_id = test_flow_id("concurrent-delete-flow")
+
+      # Set up a session
+      FlowSessionManager.join_flow(flow_id, "client-1")
+      FlowSessionManager.join_flow(flow_id, "client-2")
+
+      {:ok, _reply, socket1} =
+        subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      # Create second management channel connection
+      {:ok, socket2} = connect(UserSocket, %{}, connect_info: %{})
+
+      {:ok, _reply, socket2} =
+        subscribe_and_join(socket2, FlowManagementChannel, "flow_management")
+
+      # Send delete requests from both sockets simultaneously
+      ref1 = push(socket1, "flow_deleted", %{"flow_id" => flow_id})
+      ref2 = push(socket2, "flow_deleted", %{"flow_id" => flow_id})
+
+      # Both should receive responses (though one might get 0 clients_affected)
+      assert_reply ref1, :ok, %{status: "session_closed", clients_affected: clients1}
+      assert_reply ref2, :ok, %{status: "session_closed", clients_affected: clients2}
+
+      # Total clients affected should be 2 (or one request handles all, other gets 0)
+      assert clients1 + clients2 == 2
+
+      # Session should be closed
+      assert %{active: false, client_count: 0} = FlowSessionManager.get_flow_status(flow_id)
+    end
+  end
+
+  describe "logging behavior" do
+    test "logs invalid payload warnings", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      log =
+        capture_log([level: :warning], fn ->
+          ref = push(socket, "flow_deleted", %{"invalid" => "payload"})
+          assert_reply ref, :error, _payload
+        end)
+
+      assert log =~ "Invalid flow_deleted payload received"
+    end
+
+    test "logs unknown event warnings", %{socket: socket} do
+      {:ok, _reply, socket} = subscribe_and_join(socket, FlowManagementChannel, "flow_management")
+
+      log =
+        capture_log([level: :warning], fn ->
+          ref = push(socket, "unknown_event", %{"test" => "data"})
+          assert_reply ref, :error, _payload
+        end)
+
+      assert log =~ "Unknown management event unknown_event"
+    end
+  end
+
+  # Helper function to generate unique test flow IDs
+  defp test_flow_id(base_id) do
+    "#{base_id}-#{inspect(self())}-#{:erlang.unique_integer([:positive])}"
+  end
+end

--- a/test/helix_web/channels/user_socket_test.exs
+++ b/test/helix_web/channels/user_socket_test.exs
@@ -1,0 +1,222 @@
+defmodule HelixWeb.UserSocketTest do
+  use HelixWeb.ChannelCase, async: false
+
+  alias HelixWeb.UserSocket
+
+  describe "socket connection" do
+    test "successfully connects with empty params" do
+      assert {:ok, socket} = connect(UserSocket, %{})
+      assert socket.transport_pid != nil
+    end
+
+    test "successfully connects with arbitrary params" do
+      params = %{"user_id" => "123", "session_token" => "abc"}
+      assert {:ok, socket} = connect(UserSocket, params)
+      assert socket.transport_pid != nil
+    end
+
+    test "connects with connect_info" do
+      connect_info = %{peer_data: %{address: {127, 0, 0, 1}, port: 12_345}}
+      assert {:ok, socket} = connect(UserSocket, %{}, connect_info: connect_info)
+      assert socket.transport_pid != nil
+    end
+  end
+
+  describe "channel routing" do
+    test "routes flow channels correctly" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Test that flow channels can be joined through the socket
+      flow_id = "test-flow-#{:erlang.unique_integer([:positive])}"
+
+      # The actual channel join is tested in FlowChannelTest,
+      # here we just verify the routing is set up
+      assert {:ok, _reply, _socket} =
+               subscribe_and_join(socket, HelixWeb.FlowChannel, "flow:#{flow_id}")
+    end
+
+    test "routes flow_management channel correctly" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Test that flow_management channel can be joined through the socket
+      assert {:ok, _reply, _socket} =
+               subscribe_and_join(socket, HelixWeb.FlowManagementChannel, "flow_management")
+    end
+
+    test "rejects invalid channel topics" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Test that invalid topics are rejected
+      assert {:error, %{reason: _}} =
+               subscribe_and_join(socket, HelixWeb.FlowChannel, "invalid:topic")
+
+      assert {:error, %{reason: _}} =
+               subscribe_and_join(socket, HelixWeb.FlowManagementChannel, "invalid_topic")
+    end
+
+    test "handles non-existent channels gracefully" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Try to join a channel that doesn't exist in routing
+      # This should fail because the module doesn't exist
+      assert_raise UndefinedFunctionError, fn ->
+        subscribe_and_join(socket, NonExistentChannel, "some:topic")
+      end
+    end
+  end
+
+  describe "socket configuration" do
+    test "socket has correct transport configuration" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Verify basic socket structure (transport is a tuple in test mode)
+      assert is_tuple(socket.transport)
+      assert is_pid(socket.transport_pid)
+      assert socket.serializer != nil
+    end
+
+    test "socket allows multiple channel subscriptions" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      flow_id_1 = "flow-1-#{:erlang.unique_integer([:positive])}"
+      flow_id_2 = "flow-2-#{:erlang.unique_integer([:positive])}"
+
+      # Join multiple flow channels
+      assert {:ok, _reply1, _socket1} =
+               subscribe_and_join(socket, HelixWeb.FlowChannel, "flow:#{flow_id_1}")
+
+      # Create a new socket connection for the second channel
+      {:ok, socket2} = connect(UserSocket, %{})
+
+      assert {:ok, _reply2, _socket2} =
+               subscribe_and_join(socket2, HelixWeb.FlowChannel, "flow:#{flow_id_2}")
+
+      # Also join flow_management channel
+      {:ok, socket3} = connect(UserSocket, %{})
+
+      assert {:ok, _reply3, _socket3} =
+               subscribe_and_join(socket3, HelixWeb.FlowManagementChannel, "flow_management")
+    end
+  end
+
+  describe "socket authentication" do
+    test "socket connects without authentication requirement" do
+      # UserSocket currently doesn't require authentication
+      assert {:ok, socket} = connect(UserSocket, %{})
+      assert socket.assigns == %{}
+    end
+
+    test "socket preserves connection parameters" do
+      params = %{"custom_param" => "test_value"}
+      assert {:ok, _socket} = connect(UserSocket, params)
+
+      # The socket connection succeeds regardless of params
+      # (UserSocket doesn't currently process connect params)
+    end
+  end
+
+  describe "error handling" do
+    test "handles malformed connection parameters" do
+      # Test with nil parameters (should work)
+      assert {:ok, _socket} = connect(UserSocket, %{})
+
+      # Test with valid map parameters
+      assert {:ok, _socket} = connect(UserSocket, %{"valid" => "param"})
+    end
+
+    test "handles connection with invalid connect_info" do
+      invalid_connect_info = %{invalid: "data"}
+      assert {:ok, _socket} = connect(UserSocket, %{}, connect_info: invalid_connect_info)
+    end
+  end
+
+  describe "integration tests" do
+    test "full flow: connect socket, join channels, communicate" do
+      # Connect socket
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Join flow channel
+      flow_id = "integration-test-#{:erlang.unique_integer([:positive])}"
+
+      {:ok, _reply, flow_socket} =
+        subscribe_and_join(socket, HelixWeb.FlowChannel, "flow:#{flow_id}")
+
+      # Join management channel
+      {:ok, socket2} = connect(UserSocket, %{})
+
+      {:ok, _reply, mgmt_socket} =
+        subscribe_and_join(socket2, HelixWeb.FlowManagementChannel, "flow_management")
+
+      # Test communication through flow channel
+      ref = push(flow_socket, "ping", %{})
+      assert_reply ref, :ok, %{status: "pong"}
+
+      # Test communication through management channel
+      ref = push(mgmt_socket, "flow_deleted", %{"flow_id" => flow_id})
+      assert_reply ref, :ok, %{status: "session_closed", clients_affected: _}
+    end
+
+    test "socket handles channel disconnections gracefully" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      flow_id = "disconnect-test-#{:erlang.unique_integer([:positive])}"
+
+      {:ok, _reply, flow_socket} =
+        subscribe_and_join(socket, HelixWeb.FlowChannel, "flow:#{flow_id}")
+
+      # Enable process trapping to handle the EXIT message
+      Process.flag(:trap_exit, true)
+
+      # Close the channel
+      leave(flow_socket)
+
+      # Handle the expected EXIT message
+      assert_receive {:EXIT, _pid, {:shutdown, :left}}, 1000
+
+      # Socket should still be functional for new channel joins
+      {:ok, _reply, _mgmt_socket} =
+        subscribe_and_join(socket, HelixWeb.FlowManagementChannel, "flow_management")
+    end
+  end
+
+  describe "channel topic patterns" do
+    test "flow channel accepts various flow ID formats" do
+      # Test only valid flow ID formats based on the FlowChannel validation
+      valid_flow_ids = [
+        "simple-flow",
+        "flow_with_underscores",
+        "flow-123-abc"
+      ]
+
+      for flow_id <- valid_flow_ids do
+        {:ok, socket_new} = connect(UserSocket, %{})
+
+        assert {:ok, _reply, _socket} =
+                 subscribe_and_join(socket_new, HelixWeb.FlowChannel, "flow:#{flow_id}")
+      end
+    end
+
+    test "flow_management channel only accepts exact topic match" do
+      {:ok, socket} = connect(UserSocket, %{})
+
+      # Should accept exact match
+      assert {:ok, _reply, _socket} =
+               subscribe_and_join(socket, HelixWeb.FlowManagementChannel, "flow_management")
+
+      # Should reject variations
+      invalid_topics = [
+        "flow_management:extra",
+        "flow_management_admin",
+        "flowmanagement",
+        "flow_mgmt"
+      ]
+
+      for invalid_topic <- invalid_topics do
+        {:ok, socket_new} = connect(UserSocket, %{})
+
+        assert {:error, %{reason: _}} =
+                 subscribe_and_join(socket_new, HelixWeb.FlowManagementChannel, invalid_topic)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add immediate WebSocket flow deletion notifications

- Implement force session cleanup on flow deletion

- Add client redirection when viewing deleted flows

- Create comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HomePage["HomePage"] -- "flow deleted" --> WebSocket["WebSocket Service"]
  WebSocket -- "notify deletion" --> FlowMgmtChannel["FlowManagementChannel"]
  FlowMgmtChannel -- "force close" --> SessionManager["FlowSessionManager"]
  SessionManager -- "broadcast" --> FlowChannel["FlowChannel"]
  FlowChannel -- "redirect user" --> Browser["Browser Navigation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>useFlowManager.ts</strong><dd><code>Add flow deletion callback for user redirection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-5ae135106a6c1d633e65ddcb0739b54036665137162d87541601beca33b245a4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>websocketService.ts</strong><dd><code>Add flow deletion notification and callback handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-e1956e3e2a266deef55793f0c202362440fb96096a76cfbea02b87d9c8622fcf">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flow_session_manager.ex</strong><dd><code>Add force close session functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-64e368a64e201ad40cdbf940ef8105a70d6e989b10f3801667b1dd03b3f5d3e6">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flow_channel.ex</strong><dd><code>Handle flow deletion messages and close channels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-bd2e4ff85bb6a5d4ab0725a4b31065eb5acd0b3c89b60e74401df3d2696489ff">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flow_management_channel.ex</strong><dd><code>Create new channel for flow management operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-b232af95809677d2095f841cc338d00f41df5125537298aaedf0906ac9f7e14d">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HomePage.tsx</strong><dd><code>Add WebSocket notification on flow deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-d382161b381d42b95fbb6a7087538f6eb561a428955457a9c52f67ce0c76edc4">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>websocketService.test.ts</strong><dd><code>Add comprehensive tests for flow deletion functionality</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-42e8915fdd2952ffdd5b873fc8188a2c2b1bd06380d797b416ccfaa53963891d">+164/-28</a></td>

</tr>

<tr>
  <td><strong>flow_session_manager_test.exs</strong><dd><code>Add comprehensive force close session tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-47497df4e73ceeddedfd2bc0a03d3fa3014c8b8f3dfeb13482d713d5bf76481f">+184/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flow_channel_test.exs</strong><dd><code>Add flow deletion handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-07a465428287ee7ff72fa7bede17161d0705d914711a87effb21ed9169162641">+179/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flow_management_channel_test.exs</strong><dd><code>Create comprehensive flow management channel tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-cba14b34ffec480c091b6326642d70d05638ec1aab7449cf0a2a1b947bcf0c3d">+338/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_socket_test.exs</strong><dd><code>Add socket routing and integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-571e2c21df8cec9af549c0e8f793dc7efca2ac5b22b51ec1818c9a83ee166b35">+222/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>user_socket.ex</strong><dd><code>Add flow management channel routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/58/files#diff-b8771a6886502f0e73546bafd704b76f0a2af53be0b94443146c28de39ea4118">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

