### PR TITLE
docs: make README more concise and focused on OTP value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Open [localhost:4000](http://localhost:4000) and start designing workflows.
 - Drag and drop nodes to create workflow diagrams
 - Connect nodes to show how agents interact
 - Multiple people can edit the same workflow simultaneously
-- Changes sync in real-time via WebSockets with last-write-wins conflict resolution (concurrent edits may overwrite each other; disconnected clients' changes are not queued)
+- Real-time sync via WebSockets
+  - Last-write-wins: concurrent edits may overwrite each other
+  - No queuing: edits made while disconnected are lost and not replayed on reconnect
+  - No state resync: reconnecting clients do not receive missed changes
+  - Recommendation: coordinate edits or duplicate flows to avoid unintended overwrites
 - Sessions are managed by Elixir GenServers
 - Export diagrams as PNG images
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@
 
 Create and collaborate on AI workflow diagrams with real-time editing. Built with Elixir/Phoenix and React.
 
-> **⚠️ Early Development**: Currently focused on visual design and planning. Workflows are stored in browser localStorage. PostgreSQL persistence and execution coming in future releases.
+> ⚠️ Early Development
+>
+> - Visual design and planning only — workflows are not executable yet.
+> - Workflows are stored in the browser's localStorage (no sync/backups). Clearing browser data or switching devices will lose unsaved workflows.
+> - Server-side persistence and execution are planned for future releases.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open [localhost:4000](http://localhost:4000) and start designing workflows.
 - Drag and drop nodes to create workflow diagrams
 - Connect nodes to show how agents interact
 - Multiple people can edit the same workflow simultaneously
-- Changes sync in real-time via WebSockets with last-write-wins conflict resolution
+- Changes sync in real-time via WebSockets with last-write-wins conflict resolution (concurrent edits may overwrite each other; disconnected clients' changes are not queued)
 - Sessions are managed by Elixir GenServers
 - Export diagrams as PNG images
 

--- a/README.md
+++ b/README.md
@@ -1,93 +1,63 @@
+<div align="center">
+
 # 🧬 Helix
 
-[![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=for-the-badge)](https://github.com/ccarvalho-eng/helix/releases)
-[![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=for-the-badge&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions/workflows/ci.yml)
-[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=for-the-badge&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions/workflows/nightly-e2e-tests.yml)
-[![codecov](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=for-the-badge&logo=codecov)](https://codecov.io/gh/ccarvalho-eng/helix)
-[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=for-the-badge&logo=security&label=Security)](https://github.com/ccarvalho-eng/helix/actions/workflows/security.yml)
+**Visual workflow editor for AI agent systems**
 
-A visual workflow designer for AI agents, built with Elixir and Phoenix. Design complex multi-agent workflows using a drag-and-drop interface with real-time collaboration support.
+[![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=flat-square)](https://github.com/ccarvalho-eng/helix/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=flat-square&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions)
+[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=flat-square&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions)
+[![Coverage](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=flat-square)](https://codecov.io/gh/ccarvalho-eng/helix)
+[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=flat-square&label=Security)](https://github.com/ccarvalho-eng/helix/actions)
 
-**Key Features:**
-- Visual workflow design with node-based interface
-- Real-time collaborative editing
-- Session management powered by OTP GenServers
-- Built for reliability with supervision trees and automatic cleanup
+</div>
 
----
+Create and collaborate on AI workflow diagrams with real-time editing. Built with Elixir/Phoenix and React.
 
-## 🚀 Getting Started
+> **⚠️ Early Development**: Currently focused on visual design and planning. Workflows are stored in browser localStorage. PostgreSQL persistence and execution coming in future releases.
 
-### Requirements
-
-- Elixir **1.17+**
-- Erlang/OTP **26+**
-- Node.js **18+**
-- PostgreSQL **14+**
-
-### Installation
+## Quick Start
 
 ```bash
-# Clone
 git clone https://github.com/ccarvalho-eng/helix.git
 cd helix
-
-# Setup
 mix setup
-
-# Start
 mix phx.server
 ```
 
-Open: [http://localhost:4000](http://localhost:4000)
+Open [localhost:4000](http://localhost:4000) and start designing workflows.
 
-### Development
+**Requirements:** Elixir 1.17+, Node.js 18+, PostgreSQL 14+
+
+## What it does
+
+- Drag and drop nodes to create workflow diagrams
+- Connect nodes to show how agents interact
+- Multiple people can edit the same workflow simultaneously
+- Changes sync in real-time via WebSockets
+- Sessions are managed by Elixir GenServers
+- Export diagrams as PNG images
+
+## Development
 
 ```bash
-# Tests
-mix test
-npm test
-
-# Code quality
-mix credo --strict
-npm run lint  # Must pass with --max-warnings 0
-npm run typecheck
-
-# E2E tests
-npm run test:e2e
-
-# Formatting
-mix format
-npm run prettier
+mix test && npm test      # run all tests
+mix credo --strict        # code quality
+npm run test:e2e          # end-to-end tests
 ```
-
-## Features
-
-**Visual Design**
-- Node-based workflow editor with drag-and-drop interface
-- Customizable node types and connections
-- Minimap and zoom controls for large workflows
-
-**Collaboration**
-- Multi-user editing with WebSocket-based synchronization
-- Automatic session management via OTP GenServers
-- Conflict resolution using last-write-wins strategy
-
-**Architecture**
-- Built on Elixir/OTP for fault tolerance and concurrency
-- GraphQL API with Absinthe for flexible data fetching
-- Phoenix Channels for real-time communication
-- PostgreSQL for persistent storage
-- React + TypeScript frontend with comprehensive testing
-
 
 ## Contributing
 
-1. Fork and create a feature branch
-2. Make your changes with tests
-3. Run the test suite: `mix test && npm test`
-4. Submit a pull request
+- 🐛 **[Report bugs](https://github.com/ccarvalho-eng/helix/issues)** with reproduction steps
+- 💡 **[Request features](https://github.com/ccarvalho-eng/helix/discussions)** and share use cases
+- 🔧 **[Submit code](https://github.com/ccarvalho-eng/helix/pulls)** with tests and documentation
+
+See our [contributing guide](CONTRIBUTING.md) for more details.
 
 ## License
 
 Apache 2.0
+
+---
+
+⭐ **[Star this repo](https://github.com/ccarvalho-eng/helix)** to support development and help others discover it!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-<div align="center">
-
 # 🧬 Helix
-
-**AI Workflow Builder for Elixir**
-
-_Build robust AI agent workflows with real-time collaboration, powered by OTP fault-tolerance._
 
 [![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=for-the-badge)](https://github.com/ccarvalho-eng/helix/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=for-the-badge&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions/workflows/ci.yml)
@@ -12,19 +6,13 @@ _Build robust AI agent workflows with real-time collaboration, powered by OTP fa
 [![codecov](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=for-the-badge&logo=codecov)](https://codecov.io/gh/ccarvalho-eng/helix)
 [![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=for-the-badge&logo=security&label=Security)](https://github.com/ccarvalho-eng/helix/actions/workflows/security.yml)
 
-[Getting Started](#-getting-started) • [Features](#-features) • [Contributing](#-contributing)
+A visual workflow designer for AI agents, built with Elixir and Phoenix. Design complex multi-agent workflows using a drag-and-drop interface with real-time collaboration support.
 
----
-
-</div>
-
-Helix is a **visual AI workflow builder** that leverages Elixir's OTP architecture for robust, fault-tolerant workflow design. Unlike traditional workflow tools, Helix provides real-time collaboration through supervised GenServer processes and Phoenix Channels, ensuring your workflow sessions are resilient and automatically managed.
-
-**Why Helix?**
-- **Fault-Tolerant**: Built on OTP supervision trees with automatic session cleanup and error recovery
-- **Real-Time Collaboration**: Live multi-user editing with conflict-free synchronization
-- **Production-Ready**: Elixir's battle-tested concurrency model handles thousands of concurrent workflow sessions
-- **Developer-Friendly**: Clean drag-and-drop interface with full TypeScript support
+**Key Features:**
+- Visual workflow design with node-based interface
+- Real-time collaborative editing
+- Session management powered by OTP GenServers
+- Built for reliability with supervision trees and automatic cleanup
 
 ---
 
@@ -73,52 +61,33 @@ mix format
 npm run prettier
 ```
 
-## ✨ Features
+## Features
 
-- **🎨 Visual Workflow Design** - Intuitive drag-and-drop interface with customizable nodes and connections
-- **👥 Real-Time Collaboration** - Live multi-user editing with automatic conflict resolution
-- **⚡ Fault-Tolerant Backend** - OTP supervision trees ensure session reliability and automatic recovery
-- **🚀 Production-Ready** - Built on Phoenix/Elixir for handling thousands of concurrent users
-- **💾 Auto-Save Sessions** - GenServer automatically saves changes and manages session lifecycle
-- **🎯 Developer Experience** - Full TypeScript support with comprehensive testing
+**Visual Design**
+- Node-based workflow editor with drag-and-drop interface
+- Customizable node types and connections
+- Minimap and zoom controls for large workflows
 
-## 🏗 Architecture
+**Collaboration**
+- Multi-user editing with WebSocket-based synchronization
+- Automatic session management via OTP GenServers
+- Conflict resolution using last-write-wins strategy
 
-**OTP-Powered Session Management**
-- `FlowSessionManager` GenServer maintains workflow sessions with automatic cleanup
-- Supervised process tree ensures fault tolerance and graceful error recovery
-- Phoenix Channels provide real-time collaboration with last-write-wins conflict resolution
-- PostgreSQL persistence with local storage fallback
+**Architecture**
+- Built on Elixir/OTP for fault tolerance and concurrency
+- GraphQL API with Absinthe for flexible data fetching
+- Phoenix Channels for real-time communication
+- PostgreSQL for persistent storage
+- React + TypeScript frontend with comprehensive testing
 
-**Tech Stack**
-- **Backend:** Elixir, Phoenix, PostgreSQL
-- **Frontend:** React, TypeScript, TailwindCSS, React Flow
-- **Testing:** ExUnit, Jest, Playwright, E2E automation
 
----
+## Contributing
 
-## 🤝 Contributing
+1. Fork and create a feature branch
+2. Make your changes with tests
+3. Run the test suite: `mix test && npm test`
+4. Submit a pull request
 
-1. Fork & branch (`git checkout -b feature/amazing-feature`)
-2. Add changes + tests
-3. Run full test suite (`npm run test:all && mix test`)
-4. Commit using [Conventional Commits](https://conventionalcommits.org/)
-5. Open a pull request
+## License
 
-See [Contributing Guide](CONTRIBUTING.md) for details.
-
----
-
-## 📝 License
-
-Apache 2.0 — see [LICENSE](LICENSE).
-
----
-
-<div align="center">
-
-⭐ If you find Helix useful, [give it a star](https://github.com/ccarvalho-eng/helix/stargazers).
-
-Built with ❤️ for the AI community.
-
-</div>
+Apache 2.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ _Build robust AI agent workflows with real-time collaboration, powered by OTP fa
 
 [![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=for-the-badge)](https://github.com/ccarvalho-eng/helix/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=for-the-badge&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions/workflows/ci.yml)
+[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=for-the-badge&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions/workflows/nightly-e2e-tests.yml)
 [![codecov](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=for-the-badge&logo=codecov)](https://codecov.io/gh/ccarvalho-eng/helix)
+[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=for-the-badge&logo=security&label=Security)](https://github.com/ccarvalho-eng/helix/actions/workflows/security.yml)
 
 [Getting Started](#-getting-started) • [Features](#-features) • [Contributing](#-contributing)
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 **Visual workflow editor for AI agent systems**
 
 [![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=flat-square)](https://github.com/ccarvalho-eng/helix/releases)
-[![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=flat-square&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions)
-[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=flat-square&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions)
-[![Coverage](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=flat-square)](https://codecov.io/gh/ccarvalho-eng/helix)
-[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=flat-square&label=Security)](https://github.com/ccarvalho-eng/helix/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=flat-square&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions/workflows/ci.yml)
+[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=flat-square&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions/workflows/nightly-e2e-tests.yml)
+[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=flat-square&label=Security)](https://github.com/ccarvalho-eng/helix/actions/workflows/security.yml)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open [localhost:4000](http://localhost:4000) and start designing workflows.
 - Drag and drop nodes to create workflow diagrams
 - Connect nodes to show how agents interact
 - Multiple people can edit the same workflow simultaneously
-- Changes sync in real-time via WebSockets
+- Changes sync in real-time via WebSockets with last-write-wins conflict resolution
 - Sessions are managed by Elixir GenServers
 - Export diagrams as PNG images
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ npm run test:e2e          # end-to-end tests
 
 See our [contributing guide](CONTRIBUTING.md) for more details.
 
+## Documentation
+
+- [Architecture](docs/architecture.md) - Technical details and system diagrams
+
 ## License
 
 Apache 2.0

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Open [localhost:4000](http://localhost:4000) and start designing workflows.
   - Last-write-wins: concurrent edits may overwrite each other
   - No queuing: edits made while disconnected are lost and not replayed on reconnect
   - No state resync: reconnecting clients do not receive missed changes
+  - No granular access control: assume all connected users with the link can edit
   - Recommendation: coordinate edits or duplicate flows to avoid unintended overwrites
 - Sessions are managed by Elixir GenServers
 - Export diagrams as PNG images

--- a/README.md
+++ b/README.md
@@ -2,41 +2,27 @@
 
 # 🧬 Helix
 
-**Visual AI Agent Workflow Designer**
+**AI Workflow Builder for Elixir**
 
-_Plan, design, and visualize complex multi-agent workflows with a clean drag-and-drop interface._
+_Build robust AI agent workflows with real-time collaboration, powered by OTP fault-tolerance._
 
 [![GitHub release](https://img.shields.io/github/v/release/ccarvalho-eng/helix?style=for-the-badge)](https://github.com/ccarvalho-eng/helix/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/ci.yml?style=for-the-badge&logo=github-actions)](https://github.com/ccarvalho-eng/helix/actions/workflows/ci.yml)
-[![E2E Tests](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/nightly-e2e-tests.yml?style=for-the-badge&logo=playwright&label=E2E)](https://github.com/ccarvalho-eng/helix/actions/workflows/nightly-e2e-tests.yml)
 [![codecov](https://img.shields.io/codecov/c/github/ccarvalho-eng/helix?style=for-the-badge&logo=codecov)](https://codecov.io/gh/ccarvalho-eng/helix)
-[![Security](https://img.shields.io/github/actions/workflow/status/ccarvalho-eng/helix/security.yml?style=for-the-badge&logo=security&label=Security)](https://github.com/ccarvalho-eng/helix/actions/workflows/security.yml)
 
-[Features](#-features) • [Getting Started](#-getting-started) • [Architecture](#-architecture) • [Contributing](#-contributing)
+[Getting Started](#-getting-started) • [Features](#-features) • [Contributing](#-contributing)
 
 ---
 
 </div>
 
-## 🎯 Overview
+Helix is a **visual AI workflow builder** that leverages Elixir's OTP architecture for robust, fault-tolerant workflow design. Unlike traditional workflow tools, Helix provides real-time collaboration through supervised GenServer processes and Phoenix Channels, ensuring your workflow sessions are resilient and automatically managed.
 
-Helix is a **visual workflow designer for AI agents and multi-agent systems**.
-Build complex workflows through an intuitive node editor with collaboration, templates, and real-time updates.
-
-> **Note**: Workflows are for **planning & design only** — not executable yet.
-
----
-
-## ✨ Features
-
-- **Visual Workflow Design**
-  Drag-and-drop interface with customizable nodes, connections, minimap, and properties panel.
-- **Collaboration**
-  Real-time multi-user editing via Phoenix Channels with last-write-wins synchronization.
-- **Modern UI/UX**
-  Light/dark themes, responsive design, Tailwind styling, robust error boundaries.
-- **Workflow Management**
-  Save, load, duplicate flows, with metadata and local persistence.
+**Why Helix?**
+- **Fault-Tolerant**: Built on OTP supervision trees with automatic session cleanup and error recovery
+- **Real-Time Collaboration**: Live multi-user editing with conflict-free synchronization
+- **Production-Ready**: Elixir's battle-tested concurrency model handles thousands of concurrent workflow sessions
+- **Developer-Friendly**: Clean drag-and-drop interface with full TypeScript support
 
 ---
 
@@ -85,191 +71,27 @@ mix format
 npm run prettier
 ```
 
----
+## ✨ Features
 
-## 🛠 Tech Stack
-
-| Layer                 | Stack                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Backend**           | ![Elixir](https://img.shields.io/badge/Elixir-4B275F?logo=elixir&logoColor=white&style=for-the-badge) ![Phoenix](https://img.shields.io/badge/Phoenix-E95420?logo=phoenixframework&logoColor=white&style=for-the-badge) ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?logo=postgresql&logoColor=white&style=for-the-badge)                                                                                                                                                                                         |
-| **Frontend**          | ![React](https://img.shields.io/badge/React-20232A?logo=react&logoColor=61DAFB&style=for-the-badge) ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white&style=for-the-badge) ![TailwindCSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?logo=tailwindcss&logoColor=white&style=for-the-badge) ![Lucide Icons](https://img.shields.io/badge/Lucide-000000?logo=lucide&logoColor=white&style=for-the-badge)                                                                           |
-| **Testing & Quality** | ![ExUnit](https://img.shields.io/badge/ExUnit-4B275F?logo=elixir&logoColor=white&style=for-the-badge) ![Jest](https://img.shields.io/badge/Jest-C21325?logo=jest&logoColor=white&style=for-the-badge) ![Playwright](https://img.shields.io/badge/Playwright-2EAD33?logo=playwright&logoColor=white&style=for-the-badge) ![Credo](https://img.shields.io/badge/Credo-4B275F?logo=elixir&logoColor=white&style=for-the-badge) ![ESLint](https://img.shields.io/badge/ESLint-4B32C3?logo=eslint&logoColor=white&style=for-the-badge) |
-
----
+- **🎨 Visual Workflow Design** - Intuitive drag-and-drop interface with customizable nodes and connections
+- **👥 Real-Time Collaboration** - Live multi-user editing with automatic conflict resolution
+- **⚡ Fault-Tolerant Backend** - OTP supervision trees ensure session reliability and automatic recovery
+- **🚀 Production-Ready** - Built on Phoenix/Elixir for handling thousands of concurrent users
+- **💾 Auto-Save Sessions** - GenServer automatically saves changes and manages session lifecycle
+- **🎯 Developer Experience** - Full TypeScript support with comprehensive testing
 
 ## 🏗 Architecture
 
-### System Overview
+**OTP-Powered Session Management**
+- `FlowSessionManager` GenServer maintains workflow sessions with automatic cleanup
+- Supervised process tree ensures fault tolerance and graceful error recovery
+- Phoenix Channels provide real-time collaboration with last-write-wins conflict resolution
+- PostgreSQL persistence with local storage fallback
 
-```mermaid
-%%{init: {'theme':'neutral'}}%%
-graph TB
-    subgraph "Client Side"
-        UA[User A Browser]
-        UB[User B Browser]
-        FEA[React Frontend<br/>React Flow + TypeScript]
-        FEB[React Frontend<br/>React Flow + TypeScript]
-        LSA[Local Storage<br/>Flow Data]
-        LSB[Local Storage<br/>Flow Data]
-
-        UA --> FEA
-        UB --> FEB
-        FEA --> LSA
-        FEB --> LSB
-    end
-
-    subgraph "Network Layer"
-        WSA[WebSocket Connection A]
-        WSB[WebSocket Connection B]
-        HTTP[HTTP/REST Requests]
-
-        FEA -.->|flow_change events| WSA
-        FEB -.->|flow_change events| WSB
-        WSA -.->|flow_update events| FEA
-        WSB -.->|flow_update events| FEB
-        FEA -->|CRUD operations| HTTP
-        FEB -->|CRUD operations| HTTP
-    end
-
-    subgraph "Phoenix Server"
-        US[UserSocket<br/>WebSocket Handler]
-        FC[FlowChannel<br/>Phoenix Channel]
-        FSM[FlowSessionManager<br/>GenServer State]
-        PUB[Phoenix.PubSub<br/>Message Broadcasting]
-        API[REST API<br/>Flow CRUD]
-
-        WSA --> US
-        WSB --> US
-        US --> FC
-        FC <--> FSM
-        FSM --> PUB
-        PUB --> FC
-        HTTP --> API
-    end
-
-    subgraph "Data Layer"
-        PG[(PostgreSQL<br/>Database)]
-        API --> PG
-    end
-
-    classDef client fill:#e3f2fd,stroke:#1976d2,color:#000
-    classDef network fill:#f3e5f5,stroke:#7b1fa2,color:#000
-    classDef server fill:#e8f5e8,stroke:#388e3c,color:#000
-    classDef database fill:#fff3e0,stroke:#f57c00,color:#000
-    classDef realtime fill:#ffebee,stroke:#d32f2f,color:#000
-
-    class UA,UB,FEA,FEB,LSA,LSB client
-    class WSA,WSB,HTTP network
-    class US,API server
-    class FC,FSM,PUB realtime
-    class PG database
-```
-
-### Real-Time Collaboration Flow
-
-```mermaid
-%%{init: {'theme':'neutral'}}%%
-sequenceDiagram
-    participant UA as 👤 User A
-    participant FA as 🖥️ Frontend A
-    participant WS as 🌐 WebSocket
-    participant FC as 📡 FlowChannel
-    participant FSM as 🧠 FlowSessionManager
-    participant PUB as 📢 Phoenix.PubSub
-    participant FB as 🖥️ Frontend B
-    participant UB as 👤 User B
-
-    UA->>FA: ✏️ Create/Edit Node
-    FA->>FA: 💾 Update Local State
-    Note over FA: Debounced (500ms)
-    FA->>WS: 📤 Send flow_change event
-    WS->>FC: 📥 Receive flow_change
-    FC->>FSM: 🚀 broadcast_flow_change()
-    FSM->>FSM: ⏰ Update last_activity
-    FSM->>PUB: 📡 Phoenix.PubSub.broadcast
-    PUB->>FC: 📢 {:flow_change, data}
-    FC->>WS: 📤 Send flow_update
-    WS->>FB: 📥 Receive flow_update
-    FB->>FB: 🔄 Apply remote changes
-    FB->>UB: ✨ Visual update appears
-
-    Note over FSM: 📋 Manages client sessions<br/>⏰ Updates activity timestamps<br/>❌ No conflict resolution
-    Note over PUB: 🚀 Handles message broadcasting<br/>📡 Topic: "flow:#{flow_id}"
-```
-
-### WebSocket Conflict Resolution
-
-```mermaid
-%%{init: {'theme':'neutral'}}%%
-flowchart TD
-    A[Client A: flow_change] --> B{Connection Status}
-    A2[Client B: flow_change<br/>⚡ Concurrent Event] --> B2{Connection Status}
-
-    B -->|Connected| C[FlowChannel handles A]
-    B -->|Disconnected| D[❌ Event Lost<br/>No Queuing]
-
-    B2 -->|Connected| C2[FlowChannel handles B]
-    B2 -->|Disconnected| D2[❌ Event Lost<br/>No Queuing]
-
-    C --> E[FlowSessionManager.broadcast_flow_change]
-    C2 --> E2[FlowSessionManager.broadcast_flow_change]
-
-    E --> F{Active Session?}
-    E2 --> F2{Active Session?}
-
-    F -->|Yes| G[✅ Broadcast A to all clients<br/>Last-Write-Wins]
-    F -->|No| H[⚠️ Log: No session found]
-
-    F2 -->|Yes| G2[✅ Broadcast B to all clients<br/>⚡ Overwrites A's changes]
-    F2 -->|No| H2[⚠️ Log: No session found]
-
-    G --> I[Phoenix.PubSub broadcast]
-    G2 --> I2[Phoenix.PubSub broadcast]
-    H --> K[❌ Changes discarded]
-    H2 --> K2[❌ Changes discarded]
-
-    I --> J[All clients receive A]
-    I2 --> J2[All clients receive B<br/>🔄 Conflicts possible]
-
-    J --> L[Frontend applies A]
-    J2 --> L2[Frontend applies B<br/>May overwrite A]
-
-    subgraph "Connection Handling"
-        M[Connection Lost] --> N{Reconnection?}
-        N -->|Success| O[Auto-rejoin channel<br/>🔄 No state sync]
-        N -->|Failed| P[Exponential backoff]
-        P --> Q{Max attempts<br/>10 retries?}
-        Q -->|No| R[Wait + retry]
-        Q -->|Yes| S[❌ Give up]
-        R --> N
-        O --> T[Resume sending events]
-    end
-
-    classDef error fill:#ffebee,stroke:#d32f2f,color:#000
-    classDef success fill:#e8f5e8,stroke:#388e3c,color:#000
-    classDef warning fill:#fff3e0,stroke:#f57c00,color:#000
-    classDef conflict fill:#f3e5f5,stroke:#7b1fa2,color:#000
-    classDef info fill:#e3f2fd,stroke:#1976d2,color:#000
-
-    class D,D2,H,H2,K,K2,S error
-    class G,G2,I,I2,O,T success
-    class P,R warning
-    class A2,G2,I2,J2,L2 conflict
-    class F,F2,N,Q info
-```
-
-**Conflict Resolution Strategy:**
-
-- ❌ **No validation**: All changes are accepted and broadcasted immediately
-- ⚡ **Last-Write-Wins**: Concurrent changes overwrite each other
-- 📡 **No queuing**: Disconnected events are lost (not queued for later)
-- 🔄 **No state sync**: Reconnected clients don't get missed changes
-- ⚠️ **Session-based**: Only active sessions (with connected clients) receive broadcasts
-
-- Real-time collaboration through WebSockets + Phoenix Channels
-- React Flow for node-based workflow design
-- GenServer-based session management with last-write-wins synchronization
-- RESTful API for workflow CRUD
+**Tech Stack**
+- **Backend:** Elixir, Phoenix, PostgreSQL
+- **Frontend:** React, TypeScript, TailwindCSS, React Flow
+- **Testing:** ExUnit, Jest, Playwright, E2E automation
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create and collaborate on AI workflow diagrams with real-time editing. Built wit
 > ⚠️ Early Development
 >
 > - Visual design and planning only — workflows are not executable yet.
-> - Workflows are stored in the browser's localStorage (no sync/backups). Clearing browser data or switching devices will lose unsaved workflows.
+> - Workflows are stored in the browser's localStorage (no sync/backups). Clearing browser data or switching devices will lose unsaved workflows. To avoid data loss, export your diagrams before clearing browser data or moving to a new device.
 > - Server-side persistence and execution are planned for future releases.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mix phx.server
 
 Open [localhost:4000](http://localhost:4000) and start designing workflows.
 
-**Requirements:** Elixir 1.17+, Node.js 18+, PostgreSQL 14+
+**Requirements:** Elixir 1.17+, Erlang/OTP 26+, Node.js 18+, PostgreSQL 14+ (for development)
 
 ## What it does
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,7 +200,7 @@ Currently, workflows are persisted in browser localStorage:
 
 ## Technology Stack
 
-- **Backend**: Elixir 1.17+, Phoenix Framework, Absinthe (GraphQL)
+- **Backend**: Elixir 1.17+, Phoenix Framework
 - **Frontend**: React, TypeScript, React Flow, TailwindCSS
 - **Database**: PostgreSQL 14+ (development setup)
 - **Real-time**: Phoenix Channels, WebSockets

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,208 @@
+# Architecture
+
+This document provides detailed technical information about Helix's system architecture, real-time collaboration implementation, and design decisions.
+
+## System Overview
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+graph TB
+    subgraph "Client Side"
+        UA[User A Browser]
+        UB[User B Browser]
+        FEA[React Frontend<br/>React Flow + TypeScript]
+        FEB[React Frontend<br/>React Flow + TypeScript]
+        LSA[Local Storage<br/>Flow Data]
+        LSB[Local Storage<br/>Flow Data]
+
+        UA --> FEA
+        UB --> FEB
+        FEA --> LSA
+        FEB --> LSB
+    end
+
+    subgraph "Network Layer"
+        WSA[WebSocket Connection A]
+        WSB[WebSocket Connection B]
+        HTTP[HTTP/REST Requests]
+
+        FEA -.->|flow_change events| WSA
+        FEB -.->|flow_change events| WSB
+        WSA -.->|flow_update events| FEA
+        WSB -.->|flow_update events| FEB
+        FEA -->|CRUD operations| HTTP
+        FEB -->|CRUD operations| HTTP
+    end
+
+    subgraph "Phoenix Server"
+        US[UserSocket<br/>WebSocket Handler]
+        FC[FlowChannel<br/>Phoenix Channel]
+        FSM[FlowSessionManager<br/>GenServer State]
+        PUB[Phoenix.PubSub<br/>Message Broadcasting]
+        API[REST API<br/>Flow CRUD]
+
+        WSA --> US
+        WSB --> US
+        US --> FC
+        FC <--> FSM
+        FSM --> PUB
+        PUB --> FC
+        HTTP --> API
+    end
+
+    subgraph "Data Layer"
+        PG[(PostgreSQL<br/>Database)]
+        API --> PG
+    end
+
+    classDef client fill:#e3f2fd,stroke:#1976d2,color:#000
+    classDef network fill:#f3e5f5,stroke:#7b1fa2,color:#000
+    classDef server fill:#e8f5e8,stroke:#388e3c,color:#000
+    classDef database fill:#fff3e0,stroke:#f57c00,color:#000
+    classDef realtime fill:#ffebee,stroke:#d32f2f,color:#000
+
+    class UA,UB,FEA,FEB,LSA,LSB client
+    class WSA,WSB,HTTP network
+    class US,API server
+    class FC,FSM,PUB realtime
+    class PG database
+```
+
+## Real-Time Collaboration Flow
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+sequenceDiagram
+    participant UA as 👤 User A
+    participant FA as 🖥️ Frontend A
+    participant WS as 🌐 WebSocket
+    participant FC as 📡 FlowChannel
+    participant FSM as 🧠 FlowSessionManager
+    participant PUB as 📢 Phoenix.PubSub
+    participant FB as 🖥️ Frontend B
+    participant UB as 👤 User B
+
+    UA->>FA: ✏️ Create/Edit Node
+    FA->>FA: 💾 Update Local State
+    Note over FA: Debounced (500ms)
+    FA->>WS: 📤 Send flow_change event
+    WS->>FC: 📥 Receive flow_change
+    FC->>FSM: 🚀 broadcast_flow_change()
+    FSM->>FSM: ⏰ Update last_activity
+    FSM->>PUB: 📡 Phoenix.PubSub.broadcast
+    PUB->>FC: 📢 {:flow_change, data}
+    FC->>WS: 📤 Send flow_update
+    WS->>FB: 📥 Receive flow_update
+    FB->>FB: 🔄 Apply remote changes
+    FB->>UB: ✨ Visual update appears
+
+    Note over FSM: 📋 Manages client sessions<br/>⏰ Updates activity timestamps<br/>❌ No conflict resolution
+    Note over PUB: 🚀 Handles message broadcasting<br/>📡 Topic: "flow:#{flow_id}"
+```
+
+## WebSocket Conflict Resolution
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TD
+    A[Client A: flow_change] --> B{Connection Status}
+    A2[Client B: flow_change<br/>⚡ Concurrent Event] --> B2{Connection Status}
+
+    B -->|Connected| C[FlowChannel handles A]
+    B -->|Disconnected| D[❌ Event Lost<br/>No Queuing]
+
+    B2 -->|Connected| C2[FlowChannel handles B]
+    B2 -->|Disconnected| D2[❌ Event Lost<br/>No Queuing]
+
+    C --> E[FlowSessionManager.broadcast_flow_change]
+    C2 --> E2[FlowSessionManager.broadcast_flow_change]
+
+    E --> F{Active Session?}
+    E2 --> F2{Active Session?}
+
+    F -->|Yes| G[✅ Broadcast A to all clients<br/>Last-Write-Wins]
+    F -->|No| H[⚠️ Log: No session found]
+
+    F2 -->|Yes| G2[✅ Broadcast B to all clients<br/>⚡ Overwrites A's changes]
+    F2 -->|No| H2[⚠️ Log: No session found]
+
+    G --> I[Phoenix.PubSub broadcast]
+    G2 --> I2[Phoenix.PubSub broadcast]
+    H --> K[❌ Changes discarded]
+    H2 --> K2[❌ Changes discarded]
+
+    I --> J[All clients receive A]
+    I2 --> J2[All clients receive B<br/>🔄 Conflicts possible]
+
+    J --> L[Frontend applies A]
+    J2 --> L2[Frontend applies B<br/>May overwrite A]
+
+    subgraph "Connection Handling"
+        M[Connection Lost] --> N{Reconnection?}
+        N -->|Success| O[Auto-rejoin channel<br/>🔄 No state sync]
+        N -->|Failed| P[Exponential backoff]
+        P --> Q{Max attempts<br/>10 retries?}
+        Q -->|No| R[Wait + retry]
+        Q -->|Yes| S[❌ Give up]
+        R --> N
+        O --> T[Resume sending events]
+    end
+
+    classDef error fill:#ffebee,stroke:#d32f2f,color:#000
+    classDef success fill:#e8f5e8,stroke:#388e3c,color:#000
+    classDef warning fill:#fff3e0,stroke:#f57c00,color:#000
+    classDef conflict fill:#f3e5f5,stroke:#7b1fa2,color:#000
+    classDef info fill:#e3f2fd,stroke:#1976d2,color:#000
+
+    class D,D2,H,H2,K,K2,S error
+    class G,G2,I,I2,O,T success
+    class P,R warning
+    class A2,G2,I2,J2,L2 conflict
+    class F,F2,N,Q info
+```
+
+## Conflict Resolution Strategy
+
+- **No validation**: All changes are accepted and broadcasted immediately
+- **Last-Write-Wins**: Concurrent changes overwrite each other
+- **No queuing**: Disconnected events are lost (not queued for later)
+- **No state sync**: Reconnected clients don't get missed changes
+- **Session-based**: Only active sessions (with connected clients) receive broadcasts
+
+## Key Components
+
+### FlowSessionManager GenServer
+
+The `FlowSessionManager` is a GenServer process that maintains workflow sessions in memory:
+
+- Tracks active flow sessions and connected clients
+- Handles automatic cleanup of inactive sessions (30-minute timeout)
+- Manages session lifecycle and client join/leave operations
+- Broadcasts flow changes to all connected clients in a session
+
+### Phoenix Channels
+
+Real-time communication is handled through Phoenix Channels:
+
+- `FlowChannel` manages WebSocket connections for each workflow
+- Handles `flow_change` events from clients
+- Broadcasts `flow_update` events to all connected clients
+- Uses Phoenix PubSub for message distribution
+
+### Local Storage Persistence
+
+Currently, workflows are persisted in browser localStorage:
+
+- Each workflow has a unique ID and metadata
+- Flow data includes nodes, edges, and viewport state
+- Registry tracks all workflows with timestamps and counts
+- Automatic saving on every change with debouncing
+
+## Technology Stack
+
+- **Backend**: Elixir 1.17+, Phoenix Framework, Absinthe (GraphQL)
+- **Frontend**: React, TypeScript, React Flow, TailwindCSS
+- **Database**: PostgreSQL 14+ (development setup)
+- **Real-time**: Phoenix Channels, WebSockets
+- **State Management**: OTP GenServers, Phoenix PubSub
+- **Testing**: ExUnit, Jest, Playwright


### PR DESCRIPTION
### **User description**
- Streamlined positioning as AI workflow builder for Elixir
- Emphasized fault-tolerant OTP architecture and GenServer session management
- Removed verbose mermaid diagrams for cleaner presentation
- Highlighted unique selling points: real-time collaboration, auto-save, production-ready
- Condensed features into clear bullet points with better developer messaging


___

### **PR Type**
Documentation


___

### **Description**
- Complete README rewrite for concise, professional presentation

- Removed verbose diagrams and marketing language

- Added honest early development warning

- Streamlined from 300+ lines to ~64 lines


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Verbose README"] --> B["Content Analysis"]
  B --> C["Remove Diagrams"]
  B --> D["Simplify Language"]
  B --> E["Add Warnings"]
  C --> F["Concise README"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Complete README rewrite for professional conciseness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Reduced content from 300+ lines to ~64 lines<br> <li> Removed complex mermaid diagrams and tech stack tables<br> <li> Added early development warning with limitations<br> <li> Simplified positioning and feature descriptions<br> <li> Changed badge styles from for-the-badge to flat-square<br> <li> Streamlined installation and development sections</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/63/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+31/-268</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

