### PR TITLE
fix(flow-builder): prevent node deletion when typing in properties panel

### DIFF
--- a/assets/js/features/flow-builder/FlowBuilder.tsx
+++ b/assets/js/features/flow-builder/FlowBuilder.tsx
@@ -566,9 +566,8 @@ function FlowBuilderInternal() {
       // Check if user is typing in an input field
       const target = e.target as HTMLElement;
       const isTypingInInput =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.contentEditable === 'true';
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
 
       if (e.key === 'Delete' || e.key === 'Backspace') {
         // Only delete nodes if not typing in an input field

--- a/assets/js/features/flow-builder/FlowBuilder.tsx
+++ b/assets/js/features/flow-builder/FlowBuilder.tsx
@@ -563,8 +563,16 @@ function FlowBuilderInternal() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Check if user is typing in an input field
+      const target = e.target as HTMLElement;
+      const isTypingInInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.contentEditable === 'true';
+
       if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (selectedNode) {
+        // Only delete nodes if not typing in an input field
+        if (selectedNode && !isTypingInInput) {
           deleteNode(selectedNode.id);
         }
       }

--- a/assets/js/features/flow-builder/FlowBuilder.tsx
+++ b/assets/js/features/flow-builder/FlowBuilder.tsx
@@ -563,15 +563,42 @@ function FlowBuilderInternal() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Check if user is typing in an input field
+      // Check if user is typing in an editable context
       const target = e.target as HTMLElement;
-      const isTypingInInput =
-        target &&
-        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+
+      // Comprehensive check for editable contexts
+      const isInEditableContext = () => {
+        if (!target) return false;
+
+        // Check direct element
+        if (
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable
+        ) {
+          return true;
+        }
+
+        // Check for readonly/disabled states (these shouldn't prevent deletion)
+        if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+          if (target.readOnly || target.disabled) return false;
+        }
+
+        // Traverse up to check for contentEditable parents
+        let element = target.parentElement;
+        while (element) {
+          if (element.isContentEditable) return true;
+          element = element.parentElement;
+        }
+
+        return false;
+      };
 
       if (e.key === 'Delete' || e.key === 'Backspace') {
-        // Only delete nodes if not typing in an input field
-        if (selectedNode && !isTypingInInput) {
+        // Only delete nodes if not in editable context and event wasn't handled
+        if (selectedNode && !isInEditableContext() && !e.defaultPrevented) {
+          e.preventDefault(); // Prevent browser navigation
           deleteNode(selectedNode.id);
         }
       }

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -134,15 +134,6 @@ jest.mock('../components/DownloadButton', () => ({
   DownloadButton: () => <div data-testid='download-button' />,
 }));
 
-// Mock window location
-Object.defineProperty(window, 'location', {
-  value: {
-    pathname: '/flow/test-flow',
-    search: '',
-  },
-  writable: true,
-});
-
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -88,7 +88,7 @@ jest.mock('../templates', () => ({
 jest.mock('../components/properties', () => ({
   PropertiesPanel: ({
     selectedNode,
-    onUpdateNode
+    onUpdateNode,
   }: {
     selectedNode: TestNode | null;
     onUpdateNode: (_id: string, _updates: Record<string, unknown>) => void;
@@ -135,8 +135,13 @@ jest.mock('../components/DownloadButton', () => ({
 }));
 
 // Mock window location
-delete (window as Window & typeof globalThis).location;
-(window as Window & typeof globalThis).location = { pathname: '/flow/test-flow', search: '' } as Location;
+Object.defineProperty(window, 'location', {
+  value: {
+    pathname: '/flow/test-flow',
+    search: '',
+  },
+  writable: true,
+});
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -1,0 +1,254 @@
+describe('FlowBuilder Keyboard Event Handling Logic', () => {
+  // Mock functions to track calls
+  const mockDeleteNode = jest.fn();
+  const mockDuplicateNode = jest.fn();
+
+  const mockSelectedNode = {
+    id: 'test-node-1',
+    type: 'agent' as const,
+    label: 'Test Agent',
+    description: 'Test description',
+    color: '#f0f9ff',
+    borderColor: '#e5e7eb',
+    config: {},
+  };
+
+  // This mimics the keyboard event handler logic from FlowBuilder.tsx
+  const handleKeyDown = (
+    e: KeyboardEvent,
+    selectedNode: typeof mockSelectedNode | null,
+    deleteNode: jest.Mock,
+    duplicateNode: jest.Mock,
+    _isCanvasLocked = false
+  ) => {
+    const target = e.target as HTMLElement;
+    const isTypingInInput =
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.contentEditable === 'true';
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      // Only delete nodes if not typing in an input field
+      if (selectedNode && !isTypingInInput) {
+        deleteNode(selectedNode.id);
+      }
+    }
+
+    if (e.key === 'd' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      if (selectedNode) {
+        duplicateNode(selectedNode.id);
+      }
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Delete/Backspace key handling', () => {
+    it('should delete node when Delete key is pressed and not typing in input', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should delete node when Backspace key is pressed and not typing in input', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Backspace' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should NOT delete node when Delete key is pressed while typing in INPUT field', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'INPUT', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+
+    it('should NOT delete node when Backspace key is pressed while typing in INPUT field', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Backspace' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'INPUT', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+
+    it('should NOT delete node when Delete key is pressed while typing in TEXTAREA field', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'TEXTAREA', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+
+    it('should NOT delete node when Backspace key is pressed while typing in TEXTAREA field', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Backspace' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'TEXTAREA', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+
+    it('should NOT delete node when Delete key is pressed while typing in contentEditable element', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'true' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+
+    it('should NOT delete node when no node is selected', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, null, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Duplicate key handling', () => {
+    it('should duplicate node when Ctrl+D is pressed', () => {
+      const mockEvent = new KeyboardEvent('keydown', {
+        key: 'd',
+        ctrlKey: true,
+      });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      // Mock preventDefault
+      mockEvent.preventDefault = jest.fn();
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockDuplicateNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should duplicate node when Cmd+D is pressed (Mac)', () => {
+      const mockEvent = new KeyboardEvent('keydown', {
+        key: 'd',
+        metaKey: true,
+      });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      // Mock preventDefault
+      mockEvent.preventDefault = jest.fn();
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockDuplicateNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should NOT duplicate node when no node is selected', () => {
+      const mockEvent = new KeyboardEvent('keydown', {
+        key: 'd',
+        ctrlKey: true,
+      });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'DIV', contentEditable: 'false' },
+        writable: false,
+      });
+
+      // Mock preventDefault
+      mockEvent.preventDefault = jest.fn();
+
+      handleKeyDown(mockEvent, null, mockDeleteNode, mockDuplicateNode);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockDuplicateNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Other key handling', () => {
+    it('should handle other keys without triggering node operations', () => {
+      const testKeys = ['Enter', ' ', 'a', 'Escape', 'ArrowUp', 'ArrowDown'];
+
+      testKeys.forEach(key => {
+        const mockEvent = new KeyboardEvent('keydown', { key });
+        Object.defineProperty(mockEvent, 'target', {
+          value: { tagName: 'DIV', contentEditable: 'false' },
+          writable: false,
+        });
+
+        handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+      });
+
+      expect(mockDeleteNode).not.toHaveBeenCalled();
+      expect(mockDuplicateNode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle lowercase tagName (edge case)', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: { tagName: 'input', contentEditable: 'false' }, // lowercase
+        writable: false,
+      });
+
+      handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+
+      // In the actual DOM, tagNames are always uppercase, but if somehow we get lowercase,
+      // the current implementation will treat 'input' !== 'INPUT' as a non-input element
+      // This is acceptable behavior as it errs on the side of caution
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should handle missing target properties gracefully', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: {}, // Missing tagName and contentEditable
+        writable: false,
+      });
+
+      // Should not throw an error
+      expect(() => {
+        handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+      }).not.toThrow();
+    });
+  });
+});

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 
 // Mock ReactFlow and its dependencies
 jest.mock('reactflow', () => ({
-  ReactFlow: ({ children, ...props }: any) => (
+  ReactFlow: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
     <div data-testid='reactflow' {...props}>
       {children}
     </div>
@@ -26,7 +26,17 @@ const mockDuplicateNode = jest.fn();
 const mockUpdateFlowTitle = jest.fn();
 const mockUpdateNode = jest.fn();
 
-let mockSelectedNode: any = null;
+type TestNode = {
+  id: string;
+  type: 'agent';
+  label: string;
+  description: string;
+  color: string;
+  borderColor: string;
+  config: Record<string, unknown>;
+};
+
+let mockSelectedNode: TestNode | null = null;
 
 const mockFlowManager = {
   currentFlow: { title: 'Test Flow', id: 'test-flow' },
@@ -76,7 +86,13 @@ jest.mock('../templates', () => ({
 
 // Mock the PropertiesPanel to include actual input elements for testing
 jest.mock('../components/properties', () => ({
-  PropertiesPanel: ({ selectedNode, onUpdateNode }: any) =>
+  PropertiesPanel: ({
+    selectedNode,
+    onUpdateNode
+  }: {
+    selectedNode: TestNode | null;
+    onUpdateNode: (_id: string, _updates: Record<string, unknown>) => void;
+  }) =>
     selectedNode ? (
       <div data-testid='properties-panel'>
         <input
@@ -119,8 +135,8 @@ jest.mock('../components/DownloadButton', () => ({
 }));
 
 // Mock window location
-delete (window as any).location;
-(window as any).location = { pathname: '/flow/test-flow', search: '' };
+delete (window as Window & typeof globalThis).location;
+(window as Window & typeof globalThis).location = { pathname: '/flow/test-flow', search: '' } as Location;
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -237,15 +237,21 @@ describe('FlowBuilder Keyboard Event Handling', () => {
     it('should NOT delete node when Delete key is pressed while editing contentEditable element', () => {
       const { getByTestId } = render(<FlowBuilder />);
 
-      const contentEditable = getByTestId('node-content-editable');
+      const contentEditable = getByTestId('node-content-editable') as HTMLElement;
+
+      // Ensure the element is recognized as contentEditable in JSDOM
+      contentEditable.setAttribute('contenteditable', 'true');
+      Object.defineProperty(contentEditable, 'isContentEditable', {
+        value: true,
+        configurable: true,
+      });
+
       contentEditable.focus();
 
       // Simulate Delete key press while focused on contentEditable
       fireEvent.keyDown(contentEditable, { key: 'Delete' });
 
-      // Note: This currently fails due to isContentEditable not being properly detected in tests
-      // In real DOM, contentEditable elements have isContentEditable = true
-      expect(mockDeleteNode).toHaveBeenCalled(); // This is the current behavior, not ideal but acceptable
+      expect(mockDeleteNode).not.toHaveBeenCalled();
     });
 
     it('should NOT delete node when no node is selected', () => {

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -13,7 +13,7 @@ describe('FlowBuilder Keyboard Event Handling Logic', () => {
     config: {},
   };
 
-  // This mimics the keyboard event handler logic from FlowBuilder.tsx
+  // This mimics the improved keyboard event handler logic from FlowBuilder.tsx
   const handleKeyDown = (
     e: KeyboardEvent,
     selectedNode: typeof mockSelectedNode | null,
@@ -23,9 +23,8 @@ describe('FlowBuilder Keyboard Event Handling Logic', () => {
   ) => {
     const target = e.target as HTMLElement;
     const isTypingInInput =
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.contentEditable === 'true';
+      target &&
+      (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
 
     if (e.key === 'Delete' || e.key === 'Backspace') {
       // Only delete nodes if not typing in an input field
@@ -122,7 +121,7 @@ describe('FlowBuilder Keyboard Event Handling Logic', () => {
     it('should NOT delete node when Delete key is pressed while typing in contentEditable element', () => {
       const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
       Object.defineProperty(mockEvent, 'target', {
-        value: { tagName: 'DIV', contentEditable: 'true' },
+        value: { tagName: 'DIV', isContentEditable: true },
         writable: false,
       });
 
@@ -245,10 +244,39 @@ describe('FlowBuilder Keyboard Event Handling Logic', () => {
         writable: false,
       });
 
-      // Should not throw an error
+      // Should not throw an error and should delete node (since target exists but has no input properties)
       expect(() => {
         handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
       }).not.toThrow();
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should handle null target gracefully', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: null,
+        writable: false,
+      });
+
+      // Should not throw an error and should delete node (since null target means not in input)
+      expect(() => {
+        handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+      }).not.toThrow();
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
+    });
+
+    it('should handle undefined target gracefully', () => {
+      const mockEvent = new KeyboardEvent('keydown', { key: 'Delete' });
+      Object.defineProperty(mockEvent, 'target', {
+        value: undefined,
+        writable: false,
+      });
+
+      // Should not throw an error and should delete node (since undefined target means not in input)
+      expect(() => {
+        handleKeyDown(mockEvent, mockSelectedNode, mockDeleteNode, mockDuplicateNode);
+      }).not.toThrow();
+      expect(mockDeleteNode).toHaveBeenCalledWith('test-node-1');
     });
   });
 });

--- a/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
+++ b/assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx
@@ -3,10 +3,8 @@ import { render, fireEvent } from '@testing-library/react';
 
 // Mock ReactFlow and its dependencies
 jest.mock('reactflow', () => ({
-  ReactFlow: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
-    <div data-testid='reactflow' {...props}>
-      {children}
-    </div>
+  ReactFlow: ({ children }: { children?: React.ReactNode; [key: string]: unknown }) => (
+    <div data-testid='reactflow'>{children}</div>
   ),
   ReactFlowProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid='reactflow-provider'>{children}</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 				"react-dnd": "^16.0.1",
 				"react-dnd-html5-backend": "^16.0.1",
 				"react-dom": "^19.1.1",
-				"reactflow": "^11.11.4"
+				"reactflow": "^11.11.4",
+				"tslib": "^2.8.1"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"react-dnd": "^16.0.1",
 		"react-dnd-html5-backend": "^16.0.1",
 		"react-dom": "^19.1.1",
-		"reactflow": "^11.11.4"
+		"reactflow": "^11.11.4",
+		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.4",


### PR DESCRIPTION
### **User description**
- Check if user is typing in input/textarea/contentEditable before deleting nodes
- Add comprehensive test suite (14 tests) to verify keyboard event handling
- Fix tslib dependency issue for Apollo Client tests
- Maintain all existing keyboard shortcuts (Ctrl+D duplication, etc.)

Resolves issue where Delete/Backspace keys in properties panel inputs would unintentionally delete selected nodes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevent node deletion when typing in properties panel inputs

- Add comprehensive test suite with 14 keyboard event tests

- Fix tslib dependency for Apollo Client compatibility

- Maintain existing keyboard shortcuts functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Keyboard Event"] --> B["Check Input Type"]
  B --> C{"Is typing in input?"}
  C -->|Yes| D["Block node deletion"]
  C -->|No| E["Allow node deletion"]
  E --> F["Delete selected node"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FlowBuilder.tsx</strong><dd><code>Add input detection to prevent accidental node deletion</code>&nbsp; &nbsp; </dd></summary>
<hr>

assets/js/features/flow-builder/FlowBuilder.tsx

<ul><li>Add input type detection for keyboard events<br> <li> Check if user is typing in INPUT, TEXTAREA, or contentEditable <br>elements<br> <li> Prevent node deletion when typing in input fields<br> <li> Preserve existing keyboard shortcuts like Ctrl+D duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/72/files#diff-ee126cc7549f86d80a42a23550f25e5adaa742ccf55a4a86b521c5db2138b3db">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FlowBuilder.test.tsx</strong><dd><code>Add comprehensive keyboard event handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/js/features/flow-builder/__tests__/FlowBuilder.test.tsx

<ul><li>Create comprehensive test suite with 14 test cases<br> <li> Test Delete/Backspace key handling in various input contexts<br> <li> Verify keyboard shortcuts still work (Ctrl+D duplication)<br> <li> Cover edge cases and error handling scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/72/files#diff-cadc70f99088894f4f5286b5c3aba83dcf3bc45ad3b0b4911772967e98af5855">+254/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add tslib dependency for Apollo Client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Add tslib dependency version 2.8.1<br> <li> Fix Apollo Client compatibility issues</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/72/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

