### PR TITLE
fix(flow-builder): respect custom border color in theme-specific CSS

### DIFF
--- a/assets/css/features/flow-builder/components/flow-node.css
+++ b/assets/css/features/flow-builder/components/flow-node.css
@@ -22,7 +22,7 @@
 /* Dark theme - Remove background colors and enhance borders */
 [data-theme="dark"] .flow-node {
   background: transparent;
-  border: 0.5px solid var(--theme-text-muted);
+  border: 0.5px solid var(--node-border-color, var(--theme-text-muted));
   backdrop-filter: blur(12px);
 }
 
@@ -36,7 +36,7 @@
   box-shadow:
     0 4px 12px rgba(0, 0, 0, 0.15),
     0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 0.5px solid var(--theme-border-secondary);
+  border: 0.5px solid var(--node-border-color, var(--theme-border-secondary));
 }
 
 [data-theme="light"] .flow-node:hover {


### PR DESCRIPTION
### **User description**
Fixed CSS specificity conflict where theme-specific rules were overriding the --node-border-color custom property. Both dark and light theme rules now respect custom border colors while maintaining appropriate fallbacks to theme defaults.

Resolves #88


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed CSS specificity conflict for custom node border colors

- Updated theme-specific rules to respect `--node-border-color` property

- Maintained fallback to theme defaults when custom color not set


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Theme-specific CSS rules"] --> B["CSS specificity conflict"]
  B --> C["Custom border color ignored"]
  C --> D["Updated border property"]
  D --> E["Respects --node-border-color with fallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flow-node.css</strong><dd><code>Fix border color CSS specificity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/css/features/flow-builder/components/flow-node.css

<ul><li>Updated dark theme border property to use <code>--node-border-color</code> with <br>fallback<br> <li> Updated light theme border property to use <code>--node-border-color</code> with <br>fallback<br> <li> Maintained existing theme-specific default colors as fallbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/98/files#diff-8d2963213eb058ab8b22643ae3d400d8f7e75a4e87970b4e326dd25d1aa67eae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

