### PR TITLE
feat(flows): add GraphQL API for flow queries

### DIFF
--- a/lib/helix/flows/storage.ex
+++ b/lib/helix/flows/storage.ex
@@ -96,6 +96,41 @@ defmodule Helix.Flows.Storage do
   end
 
   @doc """
+  Gets a flow with authorization check and preloaded data (nodes and edges).
+
+  Combines authorization check and data preloading in a single operation
+  for better performance.
+
+  ## Parameters
+    - user_id: The user ID
+    - flow_id: The flow ID
+
+  ## Returns
+    - `{:ok, flow}` with nodes and edges preloaded if found and user is authorized
+    - `{:error, :not_found}` if not found
+    - `{:error, :unauthorized}` if user is not the owner
+
+  ## Examples
+
+      iex> get_user_flow_with_data(user_id, flow_id)
+      {:ok, %Flow{nodes: [...], edges: [...]}}
+  """
+  @spec get_user_flow_with_data(user_id(), flow_id()) ::
+          {:ok, Flow.t()} | {:error, :not_found | :unauthorized}
+  def get_user_flow_with_data(user_id, flow_id) do
+    case get_flow(flow_id) do
+      {:ok, %Flow{user_id: ^user_id} = flow} ->
+        {:ok, Repo.preload(flow, [:nodes, :edges])}
+
+      {:ok, _flow} ->
+        {:error, :unauthorized}
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
   Gets a flow with all nodes and edges preloaded.
 
   ## Parameters

--- a/lib/helix_web/resolvers/flows.ex
+++ b/lib/helix_web/resolvers/flows.ex
@@ -46,6 +46,7 @@ defmodule HelixWeb.Resolvers.Flows do
       {:ok, flow_with_data} -> {:ok, flow_with_data}
       {:error, :not_found} -> {:error, "Flow not found"}
       {:error, :unauthorized} -> {:error, "Unauthorized"}
+      {:error, _} -> {:error, "Flow not found"}
     end
   end
 

--- a/lib/helix_web/resolvers/flows.ex
+++ b/lib/helix_web/resolvers/flows.ex
@@ -46,7 +46,6 @@ defmodule HelixWeb.Resolvers.Flows do
       {:ok, flow_with_data} -> {:ok, flow_with_data}
       {:error, :not_found} -> {:error, "Flow not found"}
       {:error, :unauthorized} -> {:error, "Unauthorized"}
-      {:error, _} -> {:error, "Flow not found"}
     end
   end
 

--- a/lib/helix_web/resolvers/flows.ex
+++ b/lib/helix_web/resolvers/flows.ex
@@ -1,0 +1,64 @@
+defmodule HelixWeb.Resolvers.Flows do
+  @moduledoc """
+  GraphQL resolvers for Flows context.
+  """
+
+  alias Helix.Flows.Storage
+
+  @doc """
+  Lists all flows for the currently authenticated user.
+
+  Requires authentication via JWT token.
+
+  ## Returns
+    - `{:ok, [Flow.t()]}` with list of user's flows
+    - `{:error, "Not authenticated"}` when not authenticated
+  """
+  @spec list_my_flows(any(), any(), Absinthe.Resolution.t()) ::
+          {:ok, list()} | {:error, String.t()}
+  def list_my_flows(_parent, _args, %{context: %{current_user: user}}) do
+    {:ok, Storage.list_user_flows(user.id)}
+  end
+
+  def list_my_flows(_parent, _args, _resolution) do
+    {:error, "Not authenticated"}
+  end
+
+  @doc """
+  Gets a single flow by ID with authorization check.
+
+  Requires authentication and verifies that the current user owns the flow.
+  Preloads nodes and edges.
+
+  ## Parameters
+    - id: The flow's UUID
+
+  ## Returns
+    - `{:ok, Flow.t()}` with nodes and edges preloaded
+    - `{:error, "Flow not found"}` when flow doesn't exist
+    - `{:error, "Unauthorized"}` when user doesn't own the flow
+    - `{:error, "Not authenticated"}` when not authenticated
+  """
+  @spec get_flow(any(), map(), Absinthe.Resolution.t()) ::
+          {:ok, any()} | {:error, String.t()}
+  def get_flow(_parent, %{id: flow_id}, %{context: %{current_user: user}}) do
+    case Storage.get_user_flow(user.id, flow_id) do
+      {:ok, flow} ->
+        # Preload nodes and edges for the response
+        case Storage.get_flow_with_data(flow.id) do
+          {:ok, flow_with_data} -> {:ok, flow_with_data}
+          {:error, :not_found} -> {:error, "Flow not found"}
+        end
+
+      {:error, :not_found} ->
+        {:error, "Flow not found"}
+
+      {:error, :unauthorized} ->
+        {:error, "Unauthorized"}
+    end
+  end
+
+  def get_flow(_parent, _args, _resolution) do
+    {:error, "Not authenticated"}
+  end
+end

--- a/lib/helix_web/resolvers/flows.ex
+++ b/lib/helix_web/resolvers/flows.ex
@@ -42,19 +42,10 @@ defmodule HelixWeb.Resolvers.Flows do
   @spec get_flow(any(), map(), Absinthe.Resolution.t()) ::
           {:ok, any()} | {:error, String.t()}
   def get_flow(_parent, %{id: flow_id}, %{context: %{current_user: user}}) do
-    case Storage.get_user_flow(user.id, flow_id) do
-      {:ok, flow} ->
-        # Preload nodes and edges for the response
-        case Storage.get_flow_with_data(flow.id) do
-          {:ok, flow_with_data} -> {:ok, flow_with_data}
-          {:error, :not_found} -> {:error, "Flow not found"}
-        end
-
-      {:error, :not_found} ->
-        {:error, "Flow not found"}
-
-      {:error, :unauthorized} ->
-        {:error, "Unauthorized"}
+    case Storage.get_user_flow_with_data(user.id, flow_id) do
+      {:ok, flow_with_data} -> {:ok, flow_with_data}
+      {:error, :not_found} -> {:error, "Flow not found"}
+      {:error, :unauthorized} -> {:error, "Unauthorized"}
     end
   end
 

--- a/lib/helix_web/schema.ex
+++ b/lib/helix_web/schema.ex
@@ -7,13 +7,18 @@ defmodule HelixWeb.Schema do
   import_types(Absinthe.Type.Custom)
 
   alias HelixWeb.Schema.{AccountsMutations, AccountsQueries, AccountsTypes}
+  alias HelixWeb.Schema.{FlowsQueries, FlowsTypes, CustomTypes}
 
+  import_types(CustomTypes)
   import_types(AccountsTypes)
   import_types(AccountsMutations)
   import_types(AccountsQueries)
+  import_types(FlowsTypes)
+  import_types(FlowsQueries)
 
   query do
     import_fields(:accounts_queries)
+    import_fields(:flows_queries)
   end
 
   mutation do

--- a/lib/helix_web/schema/custom_types.ex
+++ b/lib/helix_web/schema/custom_types.ex
@@ -1,0 +1,54 @@
+defmodule HelixWeb.Schema.CustomTypes do
+  @moduledoc """
+  Custom scalar types for GraphQL schema.
+  """
+
+  use Absinthe.Schema.Notation
+
+  @desc """
+  The JSON scalar type represents arbitrary JSON data as a map.
+  This is used for flexible configuration data in nodes and edges.
+  """
+  scalar :json do
+    description("""
+    The `Json` scalar type represents arbitrary JSON data.
+    When returned, it's a map. When received as input, it can be a JSON string or map.
+    """)
+
+    serialize(&encode/1)
+    parse(&decode/1)
+  end
+
+  # Encode: Convert Elixir term to JSON-serializable format
+  # For maps, pass through as-is (Apollo/GraphQL clients handle JSON serialization)
+  @spec encode(term()) :: term()
+  defp encode(value), do: value
+
+  # Decode: Handle input from GraphQL queries/mutations
+  @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, map()} | :error
+  @spec decode(Absinthe.Blueprint.Input.Object.t()) :: {:ok, map()}
+  @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
+    case Jason.decode(value) do
+      {:ok, result} -> {:ok, result}
+      _ -> :error
+    end
+  end
+
+  defp decode(%Absinthe.Blueprint.Input.Object{fields: fields}) do
+    result =
+      fields
+      |> Enum.map(fn %{name: name, input_value: %{data: value}} ->
+        {name, value}
+      end)
+      |> Map.new()
+
+    {:ok, result}
+  end
+
+  defp decode(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp decode(_), do: :error
+end

--- a/lib/helix_web/schema/custom_types.ex
+++ b/lib/helix_web/schema/custom_types.ex
@@ -25,9 +25,12 @@ defmodule HelixWeb.Schema.CustomTypes do
   defp encode(value), do: value
 
   # Decode: Handle input from GraphQL queries/mutations
-  @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, map()} | :error
-  @spec decode(Absinthe.Blueprint.Input.Object.t()) :: {:ok, map()}
-  @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  @spec decode(
+          Absinthe.Blueprint.Input.String.t()
+          | Absinthe.Blueprint.Input.Object.t()
+          | Absinthe.Blueprint.Input.Null.t()
+          | any()
+        ) :: {:ok, term()} | :error
   defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
     case Jason.decode(value) do
       {:ok, result} -> {:ok, result}

--- a/lib/helix_web/schema/custom_types.ex
+++ b/lib/helix_web/schema/custom_types.ex
@@ -40,11 +40,9 @@ defmodule HelixWeb.Schema.CustomTypes do
 
   defp decode(%Absinthe.Blueprint.Input.Object{fields: fields}) do
     result =
-      fields
-      |> Enum.map(fn %{name: name, input_value: %{data: value}} ->
+      Map.new(fields, fn %{name: name, input_value: %{data: value}} ->
         {name, value}
       end)
-      |> Map.new()
 
     {:ok, result}
   end

--- a/lib/helix_web/schema/flows_queries.ex
+++ b/lib/helix_web/schema/flows_queries.ex
@@ -1,0 +1,22 @@
+defmodule HelixWeb.Schema.FlowsQueries do
+  @moduledoc """
+  GraphQL queries for Flows context.
+  """
+
+  use Absinthe.Schema.Notation
+
+  alias HelixWeb.Resolvers.Flows
+
+  object :flows_queries do
+    @desc "Get all flows for the current user"
+    field :my_flows, list_of(:flow) do
+      resolve(&Flows.list_my_flows/3)
+    end
+
+    @desc "Get a specific flow by ID"
+    field :flow, :flow do
+      arg(:id, non_null(:id))
+      resolve(&Flows.get_flow/3)
+    end
+  end
+end

--- a/lib/helix_web/schema/flows_types.ex
+++ b/lib/helix_web/schema/flows_types.ex
@@ -1,0 +1,54 @@
+defmodule HelixWeb.Schema.FlowsTypes do
+  @moduledoc """
+  GraphQL types for Flows context.
+  """
+
+  use Absinthe.Schema.Notation
+
+  @desc "A node (block) within a flow diagram"
+  object :flow_node do
+    field :id, :id, description: "The unique identifier for the node"
+    field :node_id, :string, description: "The client-side node identifier"
+    field :type, :string, description: "The type of node (e.g., agent, tool, model)"
+    field :position_x, :float, description: "X coordinate position"
+    field :position_y, :float, description: "Y coordinate position"
+    field :width, :float, description: "Width of the node"
+    field :height, :float, description: "Height of the node"
+    field :data, :json, description: "Arbitrary JSON data for node configuration"
+    field :inserted_at, :datetime, description: "When the node was created"
+    field :updated_at, :datetime, description: "When the node was last updated"
+  end
+
+  @desc "An edge (connection) between nodes in a flow diagram"
+  object :flow_edge do
+    field :id, :id, description: "The unique identifier for the edge"
+    field :edge_id, :string, description: "The client-side edge identifier"
+    field :source_node_id, :string, description: "The source node identifier"
+    field :target_node_id, :string, description: "The target node identifier"
+    field :source_handle, :string, description: "The source connection handle"
+    field :target_handle, :string, description: "The target connection handle"
+    field :edge_type, :string, description: "The type of edge connection"
+    field :animated, :boolean, description: "Whether the edge is animated"
+    field :data, :json, description: "Arbitrary JSON data for edge configuration"
+    field :inserted_at, :datetime, description: "When the edge was created"
+    field :updated_at, :datetime, description: "When the edge was last updated"
+  end
+
+  @desc "A flow diagram with nodes and edges"
+  object :flow do
+    field :id, :id, description: "The unique identifier for the flow"
+    field :user_id, :id, description: "The owner of the flow"
+    field :title, :string, description: "The flow's title"
+    field :description, :string, description: "The flow's description"
+    field :viewport_x, :float, description: "Viewport X offset"
+    field :viewport_y, :float, description: "Viewport Y offset"
+    field :viewport_zoom, :float, description: "Viewport zoom level"
+    field :version, :integer, description: "Version number for optimistic locking"
+    field :is_template, :boolean, description: "Whether this flow is a template"
+    field :template_category, :string, description: "Category for template flows"
+    field :nodes, list_of(:flow_node), description: "Nodes in this flow"
+    field :edges, list_of(:flow_edge), description: "Edges in this flow"
+    field :inserted_at, :datetime, description: "When the flow was created"
+    field :updated_at, :datetime, description: "When the flow was last updated"
+  end
+end

--- a/test/helix_web/schema/flows_queries_test.exs
+++ b/test/helix_web/schema/flows_queries_test.exs
@@ -1,0 +1,233 @@
+defmodule HelixWeb.Schema.FlowsQueriesTest do
+  use HelixWeb.GraphQLCase, async: true
+
+  import Helix.AccountsFixtures
+  import Helix.FlowsFixtures
+
+  describe "myFlows query" do
+    @my_flows_query """
+    query MyFlows {
+      myFlows {
+        id
+        title
+        description
+        viewportX
+        viewportY
+        viewportZoom
+        version
+        isTemplate
+        templateCategory
+      }
+    }
+    """
+
+    test "returns current user's flows when authenticated", %{conn: conn} do
+      {user, token} = create_user_and_token()
+      flow1 = flow_fixture(%{user_id: user.id, title: "Flow 1"})
+      flow2 = flow_fixture(%{user_id: user.id, title: "Flow 2"})
+
+      # Create another user's flow (should not be returned)
+      other_user = user_fixture()
+      _other_flow = flow_fixture(%{user_id: other_user.id, title: "Other Flow"})
+
+      response = graphql_query(conn, @my_flows_query, %{}, token)
+
+      assert %{
+               "data" => %{
+                 "myFlows" => flows
+               }
+             } = response
+
+      assert length(flows) == 2
+
+      flow_ids = Enum.map(flows, & &1["id"])
+      assert flow1.id in flow_ids
+      assert flow2.id in flow_ids
+
+      # Verify flow details
+      flow1_data = Enum.find(flows, &(&1["id"] == flow1.id))
+      assert flow1_data["title"] == "Flow 1"
+      assert flow1_data["version"] == 1
+      assert flow1_data["isTemplate"] == false
+      assert flow1_data["viewportX"] == 0.0
+      assert flow1_data["viewportY"] == 0.0
+      assert flow1_data["viewportZoom"] == 1.0
+    end
+
+    test "returns empty list when user has no flows", %{conn: conn} do
+      {_user, token} = create_user_and_token()
+
+      response = graphql_query(conn, @my_flows_query, %{}, token)
+
+      assert %{
+               "data" => %{
+                 "myFlows" => []
+               }
+             } = response
+    end
+
+    test "returns error when not authenticated", %{conn: conn} do
+      response = graphql_query(conn, @my_flows_query)
+
+      assert %{
+               "data" => %{"myFlows" => nil},
+               "errors" => [%{"message" => "Not authenticated"}]
+             } = response
+    end
+
+    test "excludes soft-deleted flows", %{conn: conn} do
+      {user, token} = create_user_and_token()
+      flow1 = flow_fixture(%{user_id: user.id, title: "Active Flow"})
+      flow2 = flow_fixture(%{user_id: user.id, title: "Deleted Flow"})
+
+      # Soft delete flow2
+      {:ok, _deleted} = Helix.Flows.Storage.delete_flow(flow2)
+
+      response = graphql_query(conn, @my_flows_query, %{}, token)
+
+      assert %{
+               "data" => %{
+                 "myFlows" => flows
+               }
+             } = response
+
+      assert length(flows) == 1
+      assert hd(flows)["id"] == flow1.id
+    end
+  end
+
+  describe "flow query" do
+    @flow_query """
+    query Flow($id: ID!) {
+      flow(id: $id) {
+        id
+        title
+        description
+        viewportX
+        viewportY
+        viewportZoom
+        version
+        isTemplate
+        templateCategory
+        nodes {
+          id
+          nodeId
+          type
+          positionX
+          positionY
+          width
+          height
+          data
+        }
+        edges {
+          id
+          edgeId
+          sourceNodeId
+          targetNodeId
+          sourceHandle
+          targetHandle
+          edgeType
+          animated
+          data
+        }
+      }
+    }
+    """
+
+    test "returns flow with nodes and edges when authenticated and authorized", %{conn: conn} do
+      {user, token} = create_user_and_token()
+
+      %{flow: flow, nodes: nodes, edges: edges} =
+        flow_with_data_fixture(%{user_id: user.id, node_count: 2})
+
+      response = graphql_query(conn, @flow_query, %{id: flow.id}, token)
+
+      assert %{
+               "data" => %{
+                 "flow" => flow_data
+               }
+             } = response
+
+      assert flow_data["id"] == flow.id
+      assert flow_data["title"] =~ "Test Flow"
+      assert flow_data["version"] == 1
+
+      # Verify nodes
+      assert length(flow_data["nodes"]) == 2
+      node_ids = Enum.map(nodes, & &1.id)
+      returned_node_ids = Enum.map(flow_data["nodes"], & &1["id"])
+      assert Enum.all?(returned_node_ids, &(&1 in node_ids))
+
+      # Verify node details
+      first_node = hd(flow_data["nodes"])
+      assert first_node["nodeId"] =~ "node-"
+      assert first_node["type"] in ["agent", "tool", "model"]
+      assert is_float(first_node["positionX"])
+      assert is_float(first_node["positionY"])
+      assert is_map(first_node["data"])
+
+      # Verify edges
+      assert length(flow_data["edges"]) == 1
+      edge_ids = Enum.map(edges, & &1.id)
+      returned_edge_ids = Enum.map(flow_data["edges"], & &1["id"])
+      assert Enum.all?(returned_edge_ids, &(&1 in edge_ids))
+
+      # Verify edge details
+      first_edge = hd(flow_data["edges"])
+      assert first_edge["edgeId"] =~ "edge-"
+      assert first_edge["sourceNodeId"] == "node-1"
+      assert first_edge["targetNodeId"] == "node-2"
+      assert is_boolean(first_edge["animated"])
+    end
+
+    test "returns error when not authenticated", %{conn: conn} do
+      user = user_fixture()
+      flow = flow_fixture(%{user_id: user.id, title: "Test Flow"})
+
+      response = graphql_query(conn, @flow_query, %{id: flow.id})
+
+      assert %{
+               "data" => %{"flow" => nil},
+               "errors" => [%{"message" => "Not authenticated"}]
+             } = response
+    end
+
+    test "returns error when flow not found", %{conn: conn} do
+      {_user, token} = create_user_and_token()
+      non_existent_id = Ecto.UUID.generate()
+
+      response = graphql_query(conn, @flow_query, %{id: non_existent_id}, token)
+
+      assert %{
+               "data" => %{"flow" => nil},
+               "errors" => [%{"message" => "Flow not found"}]
+             } = response
+    end
+
+    test "returns error when user does not own the flow", %{conn: conn} do
+      {_current_user, token} = create_user_and_token()
+      other_user = user_fixture()
+      other_flow = flow_fixture(%{user_id: other_user.id, title: "Other User's Flow"})
+
+      response = graphql_query(conn, @flow_query, %{id: other_flow.id}, token)
+
+      assert %{
+               "data" => %{"flow" => nil},
+               "errors" => [%{"message" => "Unauthorized"}]
+             } = response
+    end
+
+    test "returns error for soft-deleted flow", %{conn: conn} do
+      {user, token} = create_user_and_token()
+      flow = flow_fixture(%{user_id: user.id, title: "Deleted Flow"})
+      {:ok, _deleted} = Helix.Flows.Storage.delete_flow(flow)
+
+      response = graphql_query(conn, @flow_query, %{id: flow.id}, token)
+
+      assert %{
+               "data" => %{"flow" => nil},
+               "errors" => [%{"message" => "Flow not found"}]
+             } = response
+    end
+  end
+end


### PR DESCRIPTION
### **User description**
Implement read-only GraphQL API for flows persistence:
- Add FlowsTypes with Flow, FlowNode, FlowEdge objects
- Add FlowsQueries with myFlows and flow(id) queries
- Add Flows resolver with authorization checks
- Add JSON scalar type for node/edge data fields
- Add comprehensive tests (9 tests, all passing)

Queries:
- myFlows: Lists user's flows (excludes soft-deleted)
- flow(id): Gets single flow with nodes/edges preloaded

Authorization:
- Both queries require authentication
- flow(id) verifies user ownership before returning

Related to #30


___

### **PR Type**
Enhancement


___

### **Description**
- Add GraphQL API for flow queries with authentication

- Implement myFlows and flow(id) resolvers with authorization

- Add custom JSON scalar type for flexible data fields

- Add comprehensive test coverage (9 tests)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GraphQL Schema"] --> B["Flows Queries"]
  B --> C["Flows Resolver"]
  C --> D["Storage Layer"]
  E["Custom JSON Type"] --> A
  F["Authentication"] --> C
  G["Authorization"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flows.ex</strong><dd><code>GraphQL resolvers for flows with auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helix_web/resolvers/flows.ex

<ul><li>Add <code>list_my_flows/3</code> resolver for user's flows<br> <li> Add <code>get_flow/3</code> resolver with ownership verification<br> <li> Implement authentication and authorization checks<br> <li> Add comprehensive error handling and documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-10d69c6d2194f14784d57c2d60a2ad6aae98c67429fb578bc08bd0807410e314">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.ex</strong><dd><code>Integrate flows into GraphQL schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helix_web/schema.ex

<ul><li>Import FlowsQueries, FlowsTypes, and CustomTypes<br> <li> Add flows_queries to main query object<br> <li> Integrate flows schema into main GraphQL schema</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-43858a8138de96c80ca0a6c83468d93b64feccfbd46d1f4283fcc1af5fa9741d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>custom_types.ex</strong><dd><code>Custom JSON scalar type implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helix_web/schema/custom_types.ex

<ul><li>Add JSON scalar type for arbitrary data<br> <li> Implement encode/decode functions for JSON handling<br> <li> Support string, object, and null input formats<br> <li> Add comprehensive type documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-85bf55186a2a408603f2a3a1f8562bf1b4006e687dfed78c2c7fe97bdb8e7123">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flows_queries.ex</strong><dd><code>GraphQL query definitions for flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helix_web/schema/flows_queries.ex

<ul><li>Define <code>my_flows</code> query for user's flows list<br> <li> Define <code>flow</code> query with ID parameter<br> <li> Connect queries to resolver functions</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-fac0aacc6941042e819baf5932a9dc2f543fe7c4b8b15301820c5267b51f284d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flows_types.ex</strong><dd><code>GraphQL type definitions for flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helix_web/schema/flows_types.ex

<ul><li>Define <code>flow_node</code> object with position and data fields<br> <li> Define <code>flow_edge</code> object with connection properties<br> <li> Define <code>flow</code> object with nodes/edges relationships<br> <li> Add comprehensive field descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-e84e29389e92d44a91c9f93c5aef809c587e8eab176c7b1b1a90b287c4f4f366">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flows_queries_test.exs</strong><dd><code>Comprehensive GraphQL flows query tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/helix_web/schema/flows_queries_test.exs

<ul><li>Add 5 tests for <code>myFlows</code> query functionality<br> <li> Add 4 tests for <code>flow</code> query with authorization<br> <li> Test authentication, authorization, and error cases<br> <li> Verify data structure and relationships</ul>


</details>


  </td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/105/files#diff-6ffd11df0f8b0e8258edd2f930eb4aacd8f2ac69c806de030e4ed4280b5a8fc1">+233/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

