### PR TITLE
feat(flows): integrate WebSocket persistence for real-time flow updates

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,9 @@ config :swoosh, :api_client, false
 # Print only warnings and errors during test
 config :logger, level: :warning
 
+# Note: Database connection errors from background persistence tasks are expected
+# during test cleanup when flows are deleted while async tasks are still running.
+
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 

--- a/lib/helix/flows/types.ex
+++ b/lib/helix/flows/types.ex
@@ -15,4 +15,43 @@ defmodule Helix.Flows.Types do
 
   @type sessions_map :: %{flow_id() => session_info()}
   @type operation_result :: {:ok, client_count()} | {:error, term()}
+
+  @typedoc """
+  Represents flow data structure with nodes and edges.
+
+  This type is used for transmitting flow state between the client,
+  channel, and session server, and for persistence operations.
+  """
+  @type flow_data :: %{
+          nodes: [node_data()],
+          edges: [edge_data()],
+          viewport: viewport_data()
+        }
+
+  @type node_data :: %{
+          node_id: String.t(),
+          type: String.t(),
+          position_x: float(),
+          position_y: float(),
+          width: float() | nil,
+          height: float() | nil,
+          data: map()
+        }
+
+  @type edge_data :: %{
+          edge_id: String.t(),
+          source_node_id: String.t(),
+          target_node_id: String.t(),
+          source_handle: String.t() | nil,
+          target_handle: String.t() | nil,
+          edge_type: String.t() | nil,
+          animated: boolean(),
+          data: map()
+        }
+
+  @type viewport_data :: %{
+          x: float(),
+          y: float(),
+          zoom: float()
+        }
 end

--- a/lib/helix_web/channels/flow_channel.ex
+++ b/lib/helix_web/channels/flow_channel.ex
@@ -95,6 +95,9 @@ defmodule HelixWeb.FlowChannel do
   def handle_in("flow_change", %{"changes" => changes}, socket) do
     flow_id = socket.assigns.flow_id
 
+    # Persist changes to database (asynchronous)
+    Flows.persist_flow_changes(flow_id, changes)
+
     # Broadcast changes to other clients via the session manager
     Flows.broadcast_flow_change(flow_id, changes)
 

--- a/test/helix/flows/concurrency_test.exs
+++ b/test/helix/flows/concurrency_test.exs
@@ -1,17 +1,21 @@
 defmodule Helix.Flows.ConcurrencyTest do
-  use ExUnit.Case, async: false
+  use Helix.DataCase, async: false
 
   alias Helix.Flows.SessionServer
   import Helix.FlowTestHelper
+  import Helix.AccountsFixtures
+  import Helix.FlowsFixtures
 
   setup do
     ensure_flow_services_available()
-    :ok
+    user = user_fixture()
+    {:ok, user: user}
   end
 
   describe "concurrent session operations" do
-    test "concurrent session creation race condition" do
-      flow_id = "race-condition-test-#{System.unique_integer([:positive])}"
+    test "concurrent session creation race condition", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Start 20 concurrent attempts to create same session
       tasks =
@@ -35,8 +39,9 @@ defmodule Helix.Flows.ConcurrencyTest do
       assert %{active: true, client_count: 20} = status
     end
 
-    test "concurrent join and leave operations on same flow" do
-      flow_id = "concurrent-ops-test-#{System.unique_integer([:positive])}"
+    test "concurrent join and leave operations on same flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Start with some clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "initial-client-1")
@@ -72,8 +77,9 @@ defmodule Helix.Flows.ConcurrencyTest do
       assert status.client_count > 0
     end
 
-    test "concurrent operations on multiple flows" do
-      flow_ids = Enum.map(1..5, &"multi-flow-#{&1}-#{System.unique_integer([:positive])}")
+    test "concurrent operations on multiple flows", %{user: user} do
+      flows = Enum.map(1..5, fn _ -> flow_fixture(%{user_id: user.id}) end)
+      flow_ids = Enum.map(flows, & &1.id)
 
       # Each flow gets concurrent operations
       all_tasks =
@@ -113,8 +119,9 @@ defmodule Helix.Flows.ConcurrencyTest do
       assert length(total_registry_entries) == 5
     end
 
-    test "concurrent session termination scenarios" do
-      flow_id = "termination-test-#{System.unique_integer([:positive])}"
+    test "concurrent session termination scenarios", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Add fewer clients to reduce complexity
       clients = Enum.map(1..5, &"client-#{&1}")
@@ -138,8 +145,9 @@ defmodule Helix.Flows.ConcurrencyTest do
       assert %{active: false, client_count: 0} = SessionServer.get_flow_status(flow_id)
     end
 
-    test "high-frequency status checks don't interfere with operations" do
-      flow_id = "status-check-test-#{System.unique_integer([:positive])}"
+    test "high-frequency status checks don't interfere with operations", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Start status checking tasks
       status_tasks =
@@ -175,8 +183,9 @@ defmodule Helix.Flows.ConcurrencyTest do
       assert %{active: false, client_count: 0} = status
     end
 
-    test "concurrent broadcast operations don't block session state" do
-      flow_id = "broadcast-test-#{System.unique_integer([:positive])}"
+    test "concurrent broadcast operations don't block session state", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join some clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "client-1")

--- a/test/helix/flows/session_server_test.exs
+++ b/test/helix/flows/session_server_test.exs
@@ -1,13 +1,16 @@
 defmodule Helix.Flows.SessionServerTest do
-  use ExUnit.Case, async: false
+  use Helix.DataCase, async: false
 
   alias Helix.Flows.SessionServer
   import Helix.FlowTestHelper
+  import Helix.AccountsFixtures
+  import Helix.FlowsFixtures
 
   setup do
     # Ensure flow services are available
     ensure_flow_services_available()
-    :ok
+    user = user_fixture()
+    {:ok, user: user}
   end
 
   defp retry_get_active_sessions(retries \\ 5) do
@@ -31,28 +34,34 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "join_flow/2" do
-    test "joins a new client to a new flow" do
-      assert {:ok, 1, "client-1"} = SessionServer.join_flow("test-flow", "client-1")
+    test "joins a new client to a new flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
+
+      assert {:ok, 1, "client-1"} = SessionServer.join_flow(flow_id, "client-1")
     end
 
-    test "joins multiple clients to the same flow" do
-      flow_id = "multi-client-flow-#{System.unique_integer([:positive])}"
+    test "joins multiple clients to the same flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       assert {:ok, 1, "client-1"} = SessionServer.join_flow(flow_id, "client-1")
       assert {:ok, 2, "client-2"} = SessionServer.join_flow(flow_id, "client-2")
       assert {:ok, 3, "client-3"} = SessionServer.join_flow(flow_id, "client-3")
     end
 
-    test "handles duplicate client joins idempotently" do
-      flow_id = "duplicate-flow"
+    test "handles duplicate client joins idempotently", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       client_id = "duplicate-client"
 
       assert {:ok, 1, ^client_id} = SessionServer.join_flow(flow_id, client_id)
       assert {:ok, 1, ^client_id} = SessionServer.join_flow(flow_id, client_id)
     end
 
-    test "generates anonymous IDs for empty client IDs" do
-      flow_id = "anonymous-flow"
+    test "generates anonymous IDs for empty client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       assert {:ok, 1, _anon_id1} = SessionServer.join_flow(flow_id, "")
       assert {:ok, 2, _anon_id2} = SessionServer.join_flow(flow_id, nil)
@@ -62,8 +71,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 2} = status
     end
 
-    test "generates anonymous IDs for whitespace-only client IDs" do
-      flow_id = "whitespace-flow"
+    test "generates anonymous IDs for whitespace-only client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       assert {:ok, 1, _anon_id1} = SessionServer.join_flow(flow_id, "   ")
       assert {:ok, 2, _anon_id2} = SessionServer.join_flow(flow_id, "\t\n  ")
@@ -72,8 +82,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 2} = status
     end
 
-    test "generates anonymous IDs for non-string client IDs" do
-      flow_id = "non-string-flow"
+    test "generates anonymous IDs for non-string client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       assert {:ok, 1, _anon_id1} = SessionServer.join_flow(flow_id, 123)
       assert {:ok, 2, _anon_id2} = SessionServer.join_flow(flow_id, :atom)
@@ -84,8 +95,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 4} = status
     end
 
-    test "preserves valid client IDs with surrounding whitespace" do
-      flow_id = "preserved-whitespace-flow"
+    test "preserves valid client IDs with surrounding whitespace", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       client_id = "  valid-client  "
 
       assert {:ok, 1, trimmed_client_id} = SessionServer.join_flow(flow_id, client_id)
@@ -96,8 +108,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 1} = status
     end
 
-    test "updates last_activity timestamp when joining" do
-      flow_id = "timestamp-join-flow"
+    test "updates last_activity timestamp when joining", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       before_join = System.system_time(:second)
       assert {:ok, 1, "client-1"} = SessionServer.join_flow(flow_id, "client-1")
@@ -108,8 +121,9 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "leave_flow/2" do
-    test "allows clients to leave a flow" do
-      flow_id = "leave-test-flow"
+    test "allows clients to leave a flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       client_id = "leaving-client"
 
       # Join first
@@ -119,8 +133,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert {:ok, 0} = SessionServer.leave_flow(flow_id, client_id)
     end
 
-    test "tracks remaining client count after leaving" do
-      flow_id = "multi-leave-flow"
+    test "tracks remaining client count after leaving", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join multiple clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "client-1")
@@ -134,11 +149,13 @@ defmodule Helix.Flows.SessionServerTest do
     end
 
     test "handles leaving non-existent flow gracefully" do
-      assert {:ok, 0} = SessionServer.leave_flow("non-existent", "client-1")
+      # Non-existent flows now return an error since flow validation was added
+      assert {:error, _} = SessionServer.leave_flow("non-existent", "client-1")
     end
 
-    test "handles leaving with non-existent client gracefully" do
-      flow_id = "exists-flow"
+    test "handles leaving with non-existent client gracefully", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join one client
       assert {:ok, 1, _id} = SessionServer.join_flow(flow_id, "real-client")
@@ -147,8 +164,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert {:ok, 1} = SessionServer.leave_flow(flow_id, "fake-client")
     end
 
-    test "removes session when last client leaves" do
-      flow_id = "remove-session-flow"
+    test "removes session when last client leaves", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       client_id = "only-client"
 
       # Join and verify session exists
@@ -162,8 +180,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: false} = SessionServer.get_flow_status(flow_id)
     end
 
-    test "updates last_activity timestamp when leaving" do
-      flow_id = "timestamp-leave-flow"
+    test "updates last_activity timestamp when leaving", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join clients
       SessionServer.join_flow(flow_id, "client-1")
@@ -188,8 +207,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: false, client_count: 0} = status
     end
 
-    test "returns active status for flows with clients" do
-      flow_id = "status-test-flow"
+    test "returns active status for flows with clients", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "client-1")
@@ -200,8 +220,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert is_integer(last_activity)
     end
 
-    test "reflects real-time client count changes" do
-      flow_id = "realtime-status-flow"
+    test "reflects real-time client count changes", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Initially inactive
       assert %{active: false, client_count: 0} = SessionServer.get_flow_status(flow_id)
@@ -225,8 +246,9 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "broadcast_flow_change/2" do
-    test "broadcasts to active flow session" do
-      flow_id = "broadcast-test-flow-#{System.unique_integer([:positive])}"
+    test "broadcasts to active flow session", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       changes = %{nodes: [], edges: []}
 
       # Join a client first
@@ -256,8 +278,9 @@ defmodule Helix.Flows.SessionServerTest do
       refute_receive {:flow_change, ^changes}, 100
     end
 
-    test "updates last_activity when broadcasting" do
-      flow_id = "activity-broadcast-flow"
+    test "updates last_activity when broadcasting", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       changes = %{test: "data"}
 
       # Join client and get initial status
@@ -275,8 +298,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert updated_status.last_activity >= initial_status.last_activity
     end
 
-    test "handles complex change payloads" do
-      flow_id = "complex-changes-flow"
+    test "handles complex change payloads", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       complex_changes = %{
         nodes: [
@@ -304,8 +328,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{} = SessionServer.get_active_sessions()
     end
 
-    test "returns session information for active flows" do
-      flow_id = "active-sessions-flow"
+    test "returns session information for active flows", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "client-1")
@@ -316,9 +341,11 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{client_count: 2, last_activity: _} = session_info
     end
 
-    test "includes multiple active flows" do
-      flow_id_1 = "multi-active-flow-1"
-      flow_id_2 = "multi-active-flow-2"
+    test "includes multiple active flows", %{user: user} do
+      flow_1 = flow_fixture(%{user_id: user.id})
+      flow_2 = flow_fixture(%{user_id: user.id})
+      flow_id_1 = flow_1.id
+      flow_id_2 = flow_2.id
 
       # Set up different flows
       SessionServer.join_flow(flow_id_1, "client-1")
@@ -332,8 +359,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{client_count: 2} = info2
     end
 
-    test "excludes inactive flows" do
-      flow_id = "temporary-active-flow"
+    test "excludes inactive flows", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join then leave
       SessionServer.join_flow(flow_id, "temp-client")
@@ -349,8 +377,9 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "force_close_flow_session/1" do
-    test "closes session and returns client count" do
-      flow_id = "force-close-flow"
+    test "closes session and returns client count", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join clients
       assert {:ok, 1, _id1} = SessionServer.join_flow(flow_id, "client-1")
@@ -371,8 +400,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert {:ok, 0} = SessionServer.force_close_flow_session("non-existent")
     end
 
-    test "broadcasts flow_deleted message" do
-      flow_id = "delete-broadcast-flow"
+    test "broadcasts flow_deleted message", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join client and subscribe to PubSub
       assert {:ok, 1, _id} = SessionServer.join_flow(flow_id, "client-1")
@@ -385,8 +415,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert_receive {:flow_deleted, ^flow_id}, 1000
     end
 
-    test "cleans up client_flows mappings" do
-      flow_id = "cleanup-mappings-flow"
+    test "cleans up client_flows mappings", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join multiple clients
       SessionServer.join_flow(flow_id, "client-1")
@@ -408,8 +439,9 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "session cleanup behavior" do
-    test "sessions auto-terminate when inactive" do
-      flow_id = "auto-terminate-flow"
+    test "sessions auto-terminate when inactive", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join a client
       assert {:ok, 1, _id} = SessionServer.join_flow(flow_id, "client-1")
@@ -427,8 +459,9 @@ defmodule Helix.Flows.SessionServerTest do
   end
 
   describe "concurrent operations" do
-    test "handles concurrent joins to same flow" do
-      flow_id = "concurrent-joins-flow"
+    test "handles concurrent joins to same flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Spawn multiple processes joining the same flow
       tasks =
@@ -448,8 +481,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 10} = status
     end
 
-    test "handles concurrent joins and leaves" do
-      flow_id = "concurrent-mixed-flow"
+    test "handles concurrent joins and leaves", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join some initial clients
       Enum.each(1..5, fn i ->
@@ -479,8 +513,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: true, client_count: 7} = status
     end
 
-    test "handles concurrent force closes" do
-      flow_id = "concurrent-close-flow"
+    test "handles concurrent force closes", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join clients
       SessionServer.join_flow(flow_id, "client-1")
@@ -506,8 +541,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: false, client_count: 0} = SessionServer.get_flow_status(flow_id)
     end
 
-    test "concurrent get_or_start_session/1 calls create no duplicate sessions" do
-      flow_id = "concurrent-start-flow"
+    test "concurrent get_or_start_session/1 calls create no duplicate sessions", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Spawn multiple processes trying to get or start the same session
       tasks =
@@ -536,8 +572,9 @@ defmodule Helix.Flows.SessionServerTest do
       assert length(session_pids_for_flow) == 1
     end
 
-    test "session process crashes and recreates properly with transient restart" do
-      flow_id = "crash-recreate-flow"
+    test "session process crashes and recreates properly with transient restart", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Start a session by joining
       assert {:ok, 1, "client-1"} = SessionServer.join_flow(flow_id, "client-1")
@@ -595,25 +632,28 @@ defmodule Helix.Flows.SessionServerTest do
       assert %{active: false, client_count: 0} = SessionServer.get_flow_status("")
     end
 
-    test "handles extremely long flow and client IDs" do
-      long_flow_id = String.duplicate("a", 1000)
+    test "handles extremely long flow and client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       long_client_id = String.duplicate("b", 1000)
 
-      assert {:ok, 1, _id} = SessionServer.join_flow(long_flow_id, long_client_id)
-      assert {:ok, 0} = SessionServer.leave_flow(long_flow_id, long_client_id)
+      assert {:ok, 1, _id} = SessionServer.join_flow(flow_id, long_client_id)
+      assert {:ok, 0} = SessionServer.leave_flow(flow_id, long_client_id)
     end
 
-    test "handles unicode flow and client IDs" do
-      unicode_flow = "flow-测试-🚀-τεστ"
+    test "handles unicode flow and client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       unicode_client = "client-مرحبا-🎉-тест"
 
-      assert {:ok, 1, _id} = SessionServer.join_flow(unicode_flow, unicode_client)
-      assert %{active: true, client_count: 1} = SessionServer.get_flow_status(unicode_flow)
-      assert {:ok, 0} = SessionServer.leave_flow(unicode_flow, unicode_client)
+      assert {:ok, 1, _id} = SessionServer.join_flow(flow_id, unicode_client)
+      assert %{active: true, client_count: 1} = SessionServer.get_flow_status(flow_id)
+      assert {:ok, 0} = SessionServer.leave_flow(flow_id, unicode_client)
     end
 
-    test "generates unique anonymous IDs" do
-      flow_id = "unique-anon-flow"
+    test "generates unique anonymous IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Generate many anonymous clients
       results =

--- a/test/helix/flows_test.exs
+++ b/test/helix/flows_test.exs
@@ -1,89 +1,99 @@
 defmodule Helix.FlowsTest do
-  use ExUnit.Case, async: false
+  use Helix.DataCase, async: false
 
   alias Helix.Flows
   import Helix.FlowTestHelper
+  import Helix.AccountsFixtures
+  import Helix.FlowsFixtures
 
   setup do
     # Ensure flow services are available
     ensure_flow_services_available()
-    :ok
+    user = user_fixture()
+    {:ok, user: user}
   end
 
   describe "join_flow/2" do
-    test "allows clients to join a flow" do
-      flow_id = "test-flow"
+    test "allows clients to join a flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       client_id = "client-1"
 
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, client_id)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, client_id)
     end
 
-    test "tracks multiple clients in the same flow" do
-      flow_id = "multi-client-flow-#{System.unique_integer([:positive])}"
+    test "returns error when flow does not exist" do
+      non_existent_id = Ecto.UUID.generate()
 
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      assert {:ok, 2, _id} = Flows.join_flow(flow_id, "client-2")
-      assert {:ok, 3, _id} = Flows.join_flow(flow_id, "client-3")
+      assert {:error, :flow_not_found} = Flows.join_flow(non_existent_id, "client-1")
     end
 
-    test "handles empty client IDs by generating anonymous ones" do
-      flow_id = "anonymous-flow-#{System.unique_integer([:positive])}"
+    test "tracks multiple clients in the same flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
-      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow_id, "")
-      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow_id, nil)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      assert {:ok, 2, _id} = Flows.join_flow(flow.id, "client-2")
+      assert {:ok, 3, _id} = Flows.join_flow(flow.id, "client-3")
     end
 
-    test "handles duplicate client joins idempotently" do
-      flow_id = "duplicate-flow"
+    test "handles empty client IDs by generating anonymous ones", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+
+      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow.id, "")
+      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow.id, nil)
+    end
+
+    test "handles duplicate client joins idempotently", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       client_id = "duplicate-client"
 
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, client_id)
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, client_id)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, client_id)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, client_id)
     end
   end
 
   describe "leave_flow/2" do
-    test "allows clients to leave a flow" do
-      flow_id = "leave-test-flow"
+    test "allows clients to leave a flow", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       client_id = "leaving-client"
 
       # Join first
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, client_id)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, client_id)
 
       # Then leave
-      assert {:ok, 0} = Flows.leave_flow(flow_id, client_id)
+      assert {:ok, 0} = Flows.leave_flow(flow.id, client_id)
     end
 
-    test "tracks remaining client count after leaving" do
-      flow_id = "multi-leave-flow"
+    test "tracks remaining client count after leaving", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join multiple clients
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      assert {:ok, 2, _id} = Flows.join_flow(flow_id, "client-2")
-      assert {:ok, 3, _id} = Flows.join_flow(flow_id, "client-3")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      assert {:ok, 2, _id} = Flows.join_flow(flow.id, "client-2")
+      assert {:ok, 3, _id} = Flows.join_flow(flow.id, "client-3")
 
       # Leave one client
-      assert {:ok, 2} = Flows.leave_flow(flow_id, "client-1")
+      assert {:ok, 2} = Flows.leave_flow(flow.id, "client-1")
 
       # Leave another client
-      assert {:ok, 1} = Flows.leave_flow(flow_id, "client-2")
+      assert {:ok, 1} = Flows.leave_flow(flow.id, "client-2")
 
       # Leave last client
-      assert {:ok, 0} = Flows.leave_flow(flow_id, "client-3")
+      assert {:ok, 0} = Flows.leave_flow(flow.id, "client-3")
     end
 
     test "handles leaving non-existent flow gracefully" do
-      assert {:ok, 0} = Flows.leave_flow("non-existent", "client-1")
+      non_existent_id = Ecto.UUID.generate()
+      assert {:ok, 0} = Flows.leave_flow(non_existent_id, "client-1")
     end
 
-    test "handles leaving with non-existent client gracefully" do
-      flow_id = "exists-flow"
+    test "handles leaving with non-existent client gracefully", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join one client
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "real-client")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "real-client")
 
       # Try to leave with different client
-      assert {:ok, 1} = Flows.leave_flow(flow_id, "fake-client")
+      assert {:ok, 1} = Flows.leave_flow(flow.id, "fake-client")
     end
   end
 
@@ -93,65 +103,65 @@ defmodule Helix.FlowsTest do
       assert %{active: false, client_count: 0} = status
     end
 
-    test "returns active status for flows with clients" do
-      flow_id = "status-test-flow-#{System.unique_integer([:positive])}"
+    test "returns active status for flows with clients", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join clients
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      assert {:ok, 2, _id} = Flows.join_flow(flow_id, "client-2")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      assert {:ok, 2, _id} = Flows.join_flow(flow.id, "client-2")
 
-      status = Flows.get_flow_status(flow_id)
+      status = Flows.get_flow_status(flow.id)
       assert %{active: true, client_count: 2, last_activity: last_activity} = status
       assert is_integer(last_activity)
     end
   end
 
   describe "broadcast_flow_change/2" do
-    test "broadcasts to active flow session" do
-      flow_id = "broadcast-test-flow-#{System.unique_integer([:positive])}"
+    test "broadcasts to active flow session", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       changes = %{nodes: [], edges: []}
 
       # Join a client first
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
 
       # Subscribe to PubSub for this flow
-      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow_id}")
+      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow.id}")
 
       # Broadcast changes
-      Flows.broadcast_flow_change(flow_id, changes)
+      Flows.broadcast_flow_change(flow.id, changes)
 
       # Should receive the broadcast
       assert_receive {:flow_change, ^changes}, 1000
     end
 
-    test "does not broadcast to inactive flow session" do
-      flow_id = "inactive-broadcast-flow"
+    test "does not broadcast to inactive flow session", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       changes = %{nodes: [], edges: []}
 
       # Subscribe to PubSub for this flow
-      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow_id}")
+      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow.id}")
 
       # Broadcast without joining - should not crash but no message
-      Flows.broadcast_flow_change(flow_id, changes)
+      Flows.broadcast_flow_change(flow.id, changes)
 
       # Should not receive any message
       refute_receive {:flow_change, ^changes}, 100
     end
 
-    test "updates last_activity when broadcasting" do
-      flow_id = "activity-test-flow"
+    test "updates last_activity when broadcasting", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       changes = %{test: "data"}
 
       # Join client and get initial status
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      initial_status = Flows.get_flow_status(flow_id)
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      initial_status = Flows.get_flow_status(flow.id)
 
       # Wait a moment then broadcast
       :timer.sleep(10)
-      Flows.broadcast_flow_change(flow_id, changes)
+      Flows.broadcast_flow_change(flow.id, changes)
 
       # Status should show updated activity
-      updated_status = Flows.get_flow_status(flow_id)
+      updated_status = Flows.get_flow_status(flow.id)
       assert updated_status.last_activity >= initial_status.last_activity
     end
   end
@@ -161,35 +171,36 @@ defmodule Helix.FlowsTest do
       assert %{} = Flows.get_active_sessions()
     end
 
-    test "returns session information for active flows" do
-      flow_id = "active-session-flow"
+    test "returns session information for active flows", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join clients
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      assert {:ok, 2, _id} = Flows.join_flow(flow_id, "client-2")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      assert {:ok, 2, _id} = Flows.join_flow(flow.id, "client-2")
 
       sessions = Flows.get_active_sessions()
+      flow_id = flow.id
       assert %{^flow_id => session_info} = sessions
       assert %{client_count: 2, last_activity: _} = session_info
     end
   end
 
   describe "force_close_flow_session/1" do
-    test "closes session and returns client count" do
-      flow_id = "force-close-flow"
+    test "closes session and returns client count", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join clients
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      assert {:ok, 2, _id} = Flows.join_flow(flow_id, "client-2")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      assert {:ok, 2, _id} = Flows.join_flow(flow.id, "client-2")
 
       # Force close
-      assert {:ok, 2} = Flows.force_close_flow_session(flow_id)
+      assert {:ok, 2} = Flows.force_close_flow_session(flow.id)
 
       # Wait for termination to complete
       :timer.sleep(50)
 
       # Session should be inactive now
-      status = Flows.get_flow_status(flow_id)
+      status = Flows.get_flow_status(flow.id)
       assert %{active: false, client_count: 0} = status
     end
 
@@ -197,79 +208,80 @@ defmodule Helix.FlowsTest do
       assert {:ok, 0} = Flows.force_close_flow_session("non-existent")
     end
 
-    test "broadcasts flow_deleted message" do
-      flow_id = "delete-broadcast-flow"
+    test "broadcasts flow_deleted message", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join client and subscribe to PubSub
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
-      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow_id}")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
+      Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow.id}")
 
       # Force close
-      assert {:ok, 1} = Flows.force_close_flow_session(flow_id)
+      assert {:ok, 1} = Flows.force_close_flow_session(flow.id)
 
       # Should receive deletion broadcast
+      flow_id = flow.id
       assert_receive {:flow_deleted, ^flow_id}, 1000
     end
   end
 
   describe "client ID handling edge cases" do
-    test "handles whitespace-only client IDs" do
-      flow_id = "whitespace-client-flow"
+    test "handles whitespace-only client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Client ID with only spaces should generate anonymous ID
-      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow_id, "   ")
-      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow_id, "\t\n")
+      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow.id, "   ")
+      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow.id, "\t\n")
 
       # Should have 2 different anonymous clients
-      status = Flows.get_flow_status(flow_id)
+      status = Flows.get_flow_status(flow.id)
       assert %{active: true, client_count: 2} = status
     end
 
-    test "handles non-string client IDs" do
-      flow_id = "non-string-client-flow"
+    test "handles non-string client IDs", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Various non-string client IDs should generate anonymous IDs
-      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow_id, 123)
-      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow_id, :atom)
-      assert {:ok, 3, _generated_id3} = Flows.join_flow(flow_id, [])
-      assert {:ok, 4, _generated_id4} = Flows.join_flow(flow_id, %{})
+      assert {:ok, 1, _generated_id1} = Flows.join_flow(flow.id, 123)
+      assert {:ok, 2, _generated_id2} = Flows.join_flow(flow.id, :atom)
+      assert {:ok, 3, _generated_id3} = Flows.join_flow(flow.id, [])
+      assert {:ok, 4, _generated_id4} = Flows.join_flow(flow.id, %{})
 
-      status = Flows.get_flow_status(flow_id)
+      status = Flows.get_flow_status(flow.id)
       assert %{active: true, client_count: 4} = status
     end
 
-    test "trims valid string client IDs with whitespace" do
-      flow_id = "whitespace-preserved-flow"
+    test "trims valid string client IDs with whitespace", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
       client_id = "  valid-client  "
 
       # Should trim whitespace from client ID
-      assert {:ok, 1, "valid-client"} = Flows.join_flow(flow_id, client_id)
+      assert {:ok, 1, "valid-client"} = Flows.join_flow(flow.id, client_id)
       # Same client should have the same trimmed ID
-      assert {:ok, 1, "valid-client"} = Flows.join_flow(flow_id, client_id)
+      assert {:ok, 1, "valid-client"} = Flows.join_flow(flow.id, client_id)
 
-      status = Flows.get_flow_status(flow_id)
+      status = Flows.get_flow_status(flow.id)
       assert %{active: true, client_count: 1} = status
     end
   end
 
   describe "session cleanup behavior" do
-    test "sessions auto-terminate when no clients remain" do
-      flow_id = "cleanup-test-flow-#{System.unique_integer([:positive])}"
+    test "sessions auto-terminate when no clients remain", %{user: user} do
+      flow = flow_fixture(%{user_id: user.id})
 
       # Join a client
-      assert {:ok, 1, _id} = Flows.join_flow(flow_id, "client-1")
+      assert {:ok, 1, _id} = Flows.join_flow(flow.id, "client-1")
 
       # Verify session exists
-      assert %{active: true, client_count: 1} = Flows.get_flow_status(flow_id)
+      assert %{active: true, client_count: 1} = Flows.get_flow_status(flow.id)
 
       # Leave the client - session should terminate
-      assert {:ok, 0} = Flows.leave_flow(flow_id, "client-1")
+      assert {:ok, 0} = Flows.leave_flow(flow.id, "client-1")
 
       # Wait for termination to complete
       :timer.sleep(50)
 
       # Session should be inactive now
-      assert %{active: false, client_count: 0} = Flows.get_flow_status(flow_id)
+      assert %{active: false, client_count: 0} = Flows.get_flow_status(flow.id)
     end
   end
 end

--- a/test/helix_web/channels/flow_channel_test.exs
+++ b/test/helix_web/channels/flow_channel_test.exs
@@ -4,16 +4,20 @@ defmodule HelixWeb.FlowChannelTest do
   alias Helix.Flows
   alias HelixWeb.FlowChannel
 
+  import Helix.AccountsFixtures
+  import Helix.FlowsFixtures
+
   @moduletag :authenticated_socket
 
-  # Helper function to generate unique test flow IDs
-  defp test_flow_id(base_id) do
-    "#{base_id}-#{inspect(self())}-#{:erlang.unique_integer([:positive])}"
+  setup do
+    user = user_fixture()
+    {:ok, user: user}
   end
 
   describe "joining flow channels" do
-    test "successfully joins a valid flow channel", %{socket: socket} do
-      flow_id = test_flow_id("test-flow")
+    test "successfully joins a valid flow channel", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -33,8 +37,9 @@ defmodule HelixWeb.FlowChannelTest do
                subscribe_and_join(socket, FlowChannel, "invalid:topic")
     end
 
-    test "multiple clients can join the same flow", %{socket: socket} do
-      flow_id = "multi-client-flow"
+    test "multiple clients can join the same flow", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # First client joins
       {:ok, _reply1, _socket1} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
@@ -52,8 +57,9 @@ defmodule HelixWeb.FlowChannelTest do
                Flows.get_flow_status(flow_id)
     end
 
-    test "generates unique client IDs for different sockets", %{socket: socket} do
-      flow_id = "unique-id-test"
+    test "generates unique client IDs for different sockets", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply1, socket1} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -65,8 +71,9 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "handling flow changes" do
-    test "broadcasts flow changes to other clients", %{socket: socket} do
-      flow_id = "broadcast-test-flow"
+    test "broadcasts flow changes to other clients", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       changes = %{
         "nodes" => [%{"id" => "node-1", "type" => "agent"}],
@@ -99,8 +106,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert is_integer(timestamp)
     end
 
-    test "handles flow_change messages correctly", %{socket: socket} do
-      flow_id = "flow-change-test"
+    test "handles flow_change messages correctly", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       changes = %{
         "nodes" => [%{"id" => "node-1", "position" => %{"x" => 100, "y" => 200}}],
@@ -116,8 +124,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert_reply ref, :ok, %{status: "broadcasted"}
     end
 
-    test "receives flow changes from session manager", %{socket: socket} do
-      flow_id = "session-manager-broadcast"
+    test "receives flow changes from session manager", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       changes = %{"test" => "data"}
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
@@ -137,8 +146,9 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "ping handling" do
-    test "responds to ping messages", %{socket: socket} do
-      flow_id = "ping-test-flow"
+    test "responds to ping messages", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -149,8 +159,9 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "unknown events" do
-    test "handles unknown events gracefully", %{socket: socket} do
-      flow_id = "unknown-event-test"
+    test "handles unknown events gracefully", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
       ref = push(socket, "unknown_event", %{"some" => "payload"})
       assert_reply ref, :error, %{reason: "Unknown event"}
@@ -158,8 +169,9 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "client disconnection" do
-    test "cleans up session when client disconnects", %{socket: socket} do
-      flow_id = test_flow_id("disconnect-test-flow")
+    test "cleans up session when client disconnects", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Join and verify the session was created
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
@@ -187,9 +199,11 @@ defmodule HelixWeb.FlowChannelTest do
     end
 
     test "updates client count correctly when one of multiple clients disconnects", %{
-      socket: socket
+      socket: socket,
+      user: user
     } do
-      flow_id = test_flow_id("multi-disconnect-test")
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       # Two clients join
       {:ok, _reply1, socket1} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
       socket2 = HelixWeb.ChannelCase.create_authenticated_socket()
@@ -214,9 +228,10 @@ defmodule HelixWeb.FlowChannelTest do
                Flows.get_flow_status(flow_id)
     end
 
-    test "handles disconnection gracefully when session manager is unavailable" do
+    test "handles disconnection gracefully when session manager is unavailable", %{user: user} do
       # This tests error handling in terminate/2 with a mock socket
-      flow_id = "error-handling-test"
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Create socket without joining through proper channels to simulate error conditions
       # The socket needs more complete structure to avoid crashes
@@ -233,8 +248,9 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "integration with Flows" do
-    test "session manager state reflects channel operations", %{socket: socket} do
-      flow_id = test_flow_id("integration-test-flow")
+    test "session manager state reflects channel operations", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       # Initially no sessions
       assert %{} = Flows.get_active_sessions()
       # Client joins
@@ -275,8 +291,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert %{} = Flows.get_active_sessions()
     end
 
-    test "flow changes are properly broadcasted through PubSub", %{socket: socket} do
-      flow_id = "pubsub-test-flow"
+    test "flow changes are properly broadcasted through PubSub", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       changes = %{"nodes" => [], "edges" => []}
       # Subscribe to PubSub topic directly
       Phoenix.PubSub.subscribe(Helix.PubSub, "flow:#{flow_id}")
@@ -290,8 +307,12 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "flow deletion handling" do
-    test "handles flow_deleted message by notifying client and closing channel", %{socket: socket} do
-      flow_id = test_flow_id("flow-deleted-test")
+    test "handles flow_deleted message by notifying client and closing channel", %{
+      socket: socket,
+      user: user
+    } do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -318,8 +339,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert_receive {:EXIT, _pid, :normal}, 1000
     end
 
-    test "flow_deleted message includes correct flow_id", %{socket: socket} do
-      flow_id = test_flow_id("specific-flow-id-test")
+    test "flow_deleted message includes correct flow_id", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -340,9 +362,14 @@ defmodule HelixWeb.FlowChannelTest do
       assert_receive {:EXIT, _pid, :normal}, 1000
     end
 
-    test "flow_deleted message for different flow_id does not affect channel", %{socket: socket} do
-      flow_id = test_flow_id("my-flow")
-      other_flow_id = test_flow_id("other-flow")
+    test "flow_deleted message for different flow_id does not affect channel", %{
+      socket: socket,
+      user: user
+    } do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
+      other_flow = flow_fixture(%{user_id: user.id})
+      other_flow_id = other_flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -363,8 +390,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert_receive {:EXIT, _pid, :normal}, 1000
     end
 
-    test "multiple clients receive flow_deleted notification", %{socket: socket} do
-      flow_id = test_flow_id("multi-client-delete-test")
+    test "multiple clients receive flow_deleted notification", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       # Two clients join the same flow
       {:ok, _reply1, _socket1} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
@@ -386,8 +414,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert_receive {:socket_close, _pid2, :normal}, 1000
     end
 
-    test "flow_deleted notification timestamp is current", %{socket: socket} do
-      flow_id = test_flow_id("timestamp-test")
+    test "flow_deleted notification timestamp is current", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -414,8 +443,9 @@ defmodule HelixWeb.FlowChannelTest do
       assert_receive {:EXIT, _pid, :normal}, 1000
     end
 
-    test "flow_deleted handling with concurrent operations", %{socket: socket} do
-      flow_id = test_flow_id("concurrent-delete-test")
+    test "flow_deleted handling with concurrent operations", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -436,12 +466,12 @@ defmodule HelixWeb.FlowChannelTest do
       assert_push("flow_deleted", %{flow_id: ^flow_id, timestamp: _})
 
       # Channel should close
-      Process.flag(:trap_exit, true)
-      assert_receive {:EXIT, _pid, :normal}, 1000
+      assert_receive {:socket_close, _pid, :normal}, 1000
     end
 
-    test "flow_deleted closes channel immediately without waiting", %{socket: socket} do
-      flow_id = test_flow_id("immediate-close-test")
+    test "flow_deleted closes channel immediately without waiting", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
 
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
 
@@ -469,18 +499,20 @@ defmodule HelixWeb.FlowChannelTest do
   end
 
   describe "error edge cases" do
-    test "handles join when Flows returns error", %{socket: socket} do
+    test "handles join when Flows returns error", %{socket: socket, user: user} do
       # Mock scenario where join might fail
       # (This is a theoretical test - Flows.join_flow doesn't currently return errors)
-      flow_id = "error-test-flow"
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       # For this test, we'll test successful join since the current implementation
       # doesn't have error cases, but this structure is ready for future error handling
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
       assert socket.assigns.flow_id == flow_id
     end
 
-    test "handles malformed flow change payloads", %{socket: socket} do
-      flow_id = "malformed-payload-test"
+    test "handles malformed flow change payloads", %{socket: socket, user: user} do
+      flow = flow_fixture(%{user_id: user.id})
+      flow_id = flow.id
       {:ok, _reply, socket} = subscribe_and_join(socket, FlowChannel, "flow:#{flow_id}")
       # Send malformed payload (missing changes key)
       ref = push(socket, "flow_change", %{"invalid" => "payload"})


### PR DESCRIPTION
### **User description**
Implement Phase 4 of flow persistence (#30) by integrating database persistence into the WebSocket layer for real-time flow changes.

Changes:
- Add flow_data types for structured data transmission
- Load flow data from database on SessionServer initialization
- Persist flow changes asynchronously via FlowChannel
- Implement optimistic locking with version field
- Add database validation in join_flow to ensure flows exist
- Handle persistence errors gracefully with try/rescue
- Update all tests to use database-backed flows instead of hardcoded IDs

All 298 tests pass with clean logs.


___

### **PR Type**
Enhancement


___

### **Description**
- Integrate database persistence into WebSocket layer for flows

- Add flow validation to prevent joining non-existent flows

- Implement optimistic locking with version field for persistence

- Update all tests to use database-backed flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocket Client"] -- "flow_change" --> B["FlowChannel"]
  B -- "persist_changes" --> C["SessionServer"]
  C -- "async task" --> D["Database Storage"]
  B -- "broadcast" --> E["Other Clients"]
  F["join_flow"] -- "validate exists" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test.exs</strong><dd><code>Add database connection error note for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-ed81daa10b4c544ac7cd93900fe769744492126448488fa29aec877f408b9403">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>flows.ex</strong><dd><code>Add flow validation and persistence API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-76bd33992f61705a482f57f8050ed9a5162ed64c43e86bbd78afbc8e7c7ee6d1">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>session_server.ex</strong><dd><code>Implement database persistence and flow data loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-57a02ad595eb95501679aa571b6a99c4dc0cda62fd2db3f19518baab090b26d5">+183/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.ex</strong><dd><code>Add flow data types for persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-970f8ed658d8ffdc8a455d857438e537943bc09f0fb50591488bdbf63cf1619f">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flow_channel.ex</strong><dd><code>Add persistence call to flow change handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-bd2e4ff85bb6a5d4ab0725a4b31065eb5acd0b3c89b60e74401df3d2696489ff">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>concurrency_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-75f8d751990667eb50c8a56bb6a4ff745c80dd954ceb2458e83dd9127d5707ee">+23/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>session_server_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-19c3a9b1df7b71debba09a82351d6ca4fbf6cadae47cfb96cfbc35e5a2ca1714">+115/-75</a></td>

</tr>

<tr>
  <td><strong>supervision_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-ef568ea9cd7df7ad9254ae2cd59428d242af8f4cf886349b0c25129631fc9b75">+28/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flows_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-d1dab7bffe5939858edafbe15b73a005b41f991bfce52b4310295509c8614c23">+105/-93</a></td>

</tr>

<tr>
  <td><strong>flow_channel_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-07a465428287ee7ff72fa7bede17161d0705d914711a87effb21ed9169162641">+82/-50</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flow_management_channel_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-cba14b34ffec480c091b6326642d70d05638ec1aab7449cf0a2a1b947bcf0c3d">+24/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_socket_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-571e2c21df8cec9af549c0e8f793dc7efca2ac5b22b51ec1818c9a83ee166b35">+35/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flow_controller_test.exs</strong><dd><code>Update tests to use database-backed flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ccarvalho-eng/helix/pull/110/files#diff-c022d5fbfe741ff2f49d7671ba85d3262cf387c2dace3ffb86ef9e9e2b36a591">+33/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

